### PR TITLE
Auto-add pylint and coverage badges to README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ name: build
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
     paths-ignore: [ misc/badges/ ]
   pull_request:
     branches: [ main ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,12 +86,11 @@ jobs:
         run: |
           git config user.email "andreas.sogaard@gmail.com"
           git config user.name "Andreas Søgaard"
-      - name: Print status
-        run: git status
+          git status
       - name: Stage badges
         run: git add -f misc/badges/
-#      - name: Commit and push changes
-#        run: git commit -m "Auto-updating badges" > /dev/null && git push origin ${GITHUB_REF##*/} || echo "Nothing to push"  
+      - name: Commit and push changes
+        run: git commit -m "Auto-updating badges" > /dev/null && git push origin ${GITHUB_REF##*/} || echo "Nothing to push"  
 
   docs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # Documentation
 docs/build/html
 docs/**/*.rst
+
+# Badges
+misc/badges

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Development of a GNN based IceCube / DeepCore / Upgrade reconstruction
 
 ![build](https://github.com/icecube/gnn-reco/actions/workflows/build.yml/badge.svg)
+![build](./misc/badges/pylint.svg)
+![build](./misc/badges/coverage.svg)

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 Development of a GNN based IceCube / DeepCore / Upgrade reconstruction
 
 ![build](https://github.com/icecube/gnn-reco/actions/workflows/build.yml/badge.svg)
-![build](./misc/badges/pylint.svg)
-![build](./misc/badges/coverage.svg)
+![pylint](./misc/badges/pylint.svg)
+![coverage](./misc/badges/coverage.svg)

--- a/misc/badges/coverage.svg
+++ b/misc/badges/coverage.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="92" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="anybadge_1">
+        <rect width="92" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#anybadge_1)">
+        <path fill="#555" d="M0 0h65v20H0z"/>
+        <path fill="#e05d44" d="M65 0h27v20H65z"/>
+        <path fill="url(#b)" d="M0 0h92v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="33.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="32.5" y="14">coverage</text>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="79.5" y="15" fill="#010101" fill-opacity=".3">9%</text>
+        <text x="78.5" y="14">9%</text>
+    </g>
+</svg>

--- a/misc/badges/pylint.svg
+++ b/misc/badges/pylint.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="anybadge_1">
+        <rect width="80" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#anybadge_1)">
+        <path fill="#555" d="M0 0h44v20H0z"/>
+        <path fill="#dfb317" d="M44 0h36v20H44z"/>
+        <path fill="url(#b)" d="M0 0h80v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="23.0" y="15" fill="#010101" fill-opacity=".3">pylint</text>
+        <text x="22.0" y="14">pylint</text>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">5.31</text>
+        <text x="62.0" y="14">5.31</text>
+    </g>
+</svg>


### PR DESCRIPTION
What is say on the tin. The build pipeline already runs unit tests and linting, and creates SVG badges with the high-level results. This PR automatically means that these badges in the repo will automatically be updated and shown in the README-file. This is meant to provide a quick overview of the code quality (and hopefully inspire improvements!).