### PR TITLE
Build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,4 +111,4 @@ jobs:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs/build/html # The folder the action should deploy.
           git-config-email: andreas.sogaard@gmail.com
-          git-config-name: Andreas Søgaard'
+          git-config-name: Andreas Søgaard

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run unit tests and generate coverage report
         run: |
           set -o pipefail  # To propagate exit code from pytest
-          coverage run --source=src -m pytest tests/ | tee results_pytest.txt
+          coverage run --source=gnn_reco -m pytest tests/ | tee results_pytest.txt
           coverage report -m | tee results_coverage.txt
       - name: Generate unit test/build and coverage badges
         run: |
@@ -110,5 +110,5 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs/build/html # The folder the action should deploy.
-          email: andreas.sogaard@gmail.com
-          name: Andreas Søgaard
+          git-config-email: andreas.sogaard@gmail.com
+          git-config-name: Andreas Søgaard'

--- a/misc/badges/coverage.svg
+++ b/misc/badges/coverage.svg
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="92" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <mask id="anybadge_1">
-        <rect width="92" height="20" rx="3" fill="#fff"/>
+        <rect width="99" height="20" rx="3" fill="#fff"/>
     </mask>
     <g mask="url(#anybadge_1)">
         <path fill="#555" d="M0 0h65v20H0z"/>
-        <path fill="#e05d44" d="M65 0h27v20H65z"/>
-        <path fill="url(#b)" d="M0 0h92v20H0z"/>
+        <path fill="#e05d44" d="M65 0h34v20H65z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="33.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="79.5" y="15" fill="#010101" fill-opacity=".3">0%</text>
-        <text x="78.5" y="14">0%</text>
+        <text x="83.0" y="15" fill="#010101" fill-opacity=".3">12%</text>
+        <text x="82.0" y="14">12%</text>
     </g>
 </svg>


### PR DESCRIPTION
Have coverage script point to `gnn_reco` package rather than `src/` directory for source code, as the latter only works if the package is installed as locally editable (i.e., `pip install -e (...)`). This change should produce actual coverage results and, as a result, an informative coverage badge.

Also fixed a warning from github-pages action, by replacing `{name,email}` variables with `git-config-{name,email}`.