### PR TITLE
Comparison study of new vs. legacy model implementations

### DIFF
--- a/misc/badges/pylint.svg
+++ b/misc/badges/pylint.svg
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="73" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <mask id="anybadge_1">
-        <rect width="80" height="20" rx="3" fill="#fff"/>
+        <rect width="73" height="20" rx="3" fill="#fff"/>
     </mask>
     <g mask="url(#anybadge_1)">
         <path fill="#555" d="M0 0h44v20H0z"/>
-        <path fill="#e05d44" d="M44 0h36v20H44z"/>
-        <path fill="url(#b)" d="M0 0h80v20H0z"/>
+        <path fill="#e05d44" d="M44 0h29v20H44z"/>
+        <path fill="url(#b)" d="M0 0h73v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="23.0" y="15" fill="#010101" fill-opacity=".3">pylint</text>
         <text x="22.0" y="14">pylint</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">1.32</text>
-        <text x="62.0" y="14">1.32</text>
+        <text x="59.5" y="15" fill="#010101" fill-opacity=".3">1.4</text>
+        <text x="58.5" y="14">1.4</text>
     </g>
 </svg>

--- a/notebooks/compare_new_vs_legacy_model_implementation.ipynb
+++ b/notebooks/compare_new_vs_legacy_model_implementation.ipynb
@@ -1,0 +1,513 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import(s)\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Common variables\n",
+    "rad_to_deg = 180. / np.pi\n",
+    "nb_bins = 50\n",
+    "var = 'azimuth'\n",
+    "vmin, vmax = {\n",
+    "    'zenith':  (0,     np.pi * rad_to_deg),\n",
+    "    'azimuth': (0, 2 * np.pi * rad_to_deg),\n",
+    "}[var]\n",
+    "results_dir = \"/groups/icecube/asogaard/gnn/results/von_mises-fisher_test/dev_level7_noise_muon_nu_classification_pass2_fixedRetro_v3/\"\n",
+    "path_new = results_dir + f\"dynedge_{var}/results.csv\"\n",
+    "path_leg = results_dir + f\"dynedge_{var}_legacy/results.csv\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Utility method(s)\n",
+    "def wrap_to_minus_180_to_180(x):\n",
+    "    if x > 180:\n",
+    "        return x - 360.\n",
+    "    elif x < -180:\n",
+    "        return x + 360.\n",
+    "    else:\n",
+    "        return x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>azimuth_pred</th>\n",
+       "      <th>azimuth_kappa</th>\n",
+       "      <th>event_no</th>\n",
+       "      <th>energy</th>\n",
+       "      <th>azimuth</th>\n",
+       "      <th>truth</th>\n",
+       "      <th>pred</th>\n",
+       "      <th>sigma</th>\n",
+       "      <th>residual</th>\n",
+       "      <th>pull</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.810002</td>\n",
+       "      <td>1.391108</td>\n",
+       "      <td>34270388</td>\n",
+       "      <td>25.195690</td>\n",
+       "      <td>3.618952</td>\n",
+       "      <td>207.350693</td>\n",
+       "      <td>161.001255</td>\n",
+       "      <td>48.578292</td>\n",
+       "      <td>-46.349438</td>\n",
+       "      <td>-0.954118</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.546938</td>\n",
+       "      <td>1.331275</td>\n",
+       "      <td>57933506</td>\n",
+       "      <td>14.451158</td>\n",
+       "      <td>1.895271</td>\n",
+       "      <td>108.591047</td>\n",
+       "      <td>31.337222</td>\n",
+       "      <td>49.657953</td>\n",
+       "      <td>-77.253825</td>\n",
+       "      <td>-1.555719</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5.779996</td>\n",
+       "      <td>1.568874</td>\n",
+       "      <td>31662171</td>\n",
+       "      <td>19.290771</td>\n",
+       "      <td>0.250358</td>\n",
+       "      <td>14.344476</td>\n",
+       "      <td>331.169376</td>\n",
+       "      <td>45.743409</td>\n",
+       "      <td>-43.175100</td>\n",
+       "      <td>-0.943854</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3.193939</td>\n",
+       "      <td>1.957762</td>\n",
+       "      <td>23689459</td>\n",
+       "      <td>53.034725</td>\n",
+       "      <td>3.957137</td>\n",
+       "      <td>226.727243</td>\n",
+       "      <td>182.999208</td>\n",
+       "      <td>40.948943</td>\n",
+       "      <td>-43.728036</td>\n",
+       "      <td>-1.067867</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.888027</td>\n",
+       "      <td>0.328073</td>\n",
+       "      <td>10539253</td>\n",
+       "      <td>26.428728</td>\n",
+       "      <td>5.975599</td>\n",
+       "      <td>342.376620</td>\n",
+       "      <td>50.880179</td>\n",
+       "      <td>100.031695</td>\n",
+       "      <td>68.503559</td>\n",
+       "      <td>0.684819</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   azimuth_pred  azimuth_kappa  event_no     energy   azimuth       truth  \\\n",
+       "0      2.810002       1.391108  34270388  25.195690  3.618952  207.350693   \n",
+       "1      0.546938       1.331275  57933506  14.451158  1.895271  108.591047   \n",
+       "2      5.779996       1.568874  31662171  19.290771  0.250358   14.344476   \n",
+       "3      3.193939       1.957762  23689459  53.034725  3.957137  226.727243   \n",
+       "4      0.888027       0.328073  10539253  26.428728  5.975599  342.376620   \n",
+       "\n",
+       "         pred       sigma   residual      pull  \n",
+       "0  161.001255   48.578292 -46.349438 -0.954118  \n",
+       "1   31.337222   49.657953 -77.253825 -1.555719  \n",
+       "2  331.169376   45.743409 -43.175100 -0.943854  \n",
+       "3  182.999208   40.948943 -43.728036 -1.067867  \n",
+       "4   50.880179  100.031695  68.503559  0.684819  "
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load new results\n",
+    "df_new = pd.read_csv(path_new, index_col=0)\n",
+    "df_new['truth'] = rad_to_deg * df_new[var]\n",
+    "df_new['pred'] = rad_to_deg * df_new[f\"{var}_pred\"]\n",
+    "df_new['sigma'] = rad_to_deg * 1./np.sqrt(df_new[f'{var}_kappa'])\n",
+    "df_new['residual'] = df_new.pred - df_new.truth\n",
+    "if var == 'azimuth':\n",
+    "    df_new.loc[df_new.pred < 0, 'pred'] = df_new.loc[df_new.pred < 0, 'pred'] + 360.\n",
+    "    df_new['residual'] = df_new.apply(lambda row: wrap_to_minus_180_to_180(row.residual), axis=1)\n",
+    "df_new['pull'] = df_new.residual / df_new.sigma\n",
+    "df_new.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>azimuth_pred</th>\n",
+       "      <th>azimuth_var</th>\n",
+       "      <th>event_no</th>\n",
+       "      <th>azimuth</th>\n",
+       "      <th>truth</th>\n",
+       "      <th>pred</th>\n",
+       "      <th>sigma</th>\n",
+       "      <th>residual</th>\n",
+       "      <th>pull</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.447901</td>\n",
+       "      <td>0.159023</td>\n",
+       "      <td>5301736</td>\n",
+       "      <td>1.397253</td>\n",
+       "      <td>80.056688</td>\n",
+       "      <td>82.958605</td>\n",
+       "      <td>22.848224</td>\n",
+       "      <td>2.901917</td>\n",
+       "      <td>0.127008</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>-1.363042</td>\n",
+       "      <td>0.099306</td>\n",
+       "      <td>42217846</td>\n",
+       "      <td>5.747718</td>\n",
+       "      <td>329.320000</td>\n",
+       "      <td>281.903417</td>\n",
+       "      <td>18.055495</td>\n",
+       "      <td>-47.416583</td>\n",
+       "      <td>-2.626158</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.511628</td>\n",
+       "      <td>0.297803</td>\n",
+       "      <td>112062</td>\n",
+       "      <td>0.255649</td>\n",
+       "      <td>14.647609</td>\n",
+       "      <td>86.609905</td>\n",
+       "      <td>31.267075</td>\n",
+       "      <td>71.962296</td>\n",
+       "      <td>2.301536</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>-2.446742</td>\n",
+       "      <td>0.054431</td>\n",
+       "      <td>84211420</td>\n",
+       "      <td>3.752505</td>\n",
+       "      <td>215.002676</td>\n",
+       "      <td>219.812033</td>\n",
+       "      <td>13.367306</td>\n",
+       "      <td>4.809357</td>\n",
+       "      <td>0.359785</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.034387</td>\n",
+       "      <td>0.243713</td>\n",
+       "      <td>44923687</td>\n",
+       "      <td>5.853769</td>\n",
+       "      <td>335.396275</td>\n",
+       "      <td>1.970210</td>\n",
+       "      <td>28.285361</td>\n",
+       "      <td>26.573935</td>\n",
+       "      <td>0.939494</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   azimuth_pred  azimuth_var  event_no   azimuth       truth        pred  \\\n",
+       "0      1.447901     0.159023   5301736  1.397253   80.056688   82.958605   \n",
+       "1     -1.363042     0.099306  42217846  5.747718  329.320000  281.903417   \n",
+       "2      1.511628     0.297803    112062  0.255649   14.647609   86.609905   \n",
+       "3     -2.446742     0.054431  84211420  3.752505  215.002676  219.812033   \n",
+       "4      0.034387     0.243713  44923687  5.853769  335.396275    1.970210   \n",
+       "\n",
+       "       sigma   residual      pull  \n",
+       "0  22.848224   2.901917  0.127008  \n",
+       "1  18.055495 -47.416583 -2.626158  \n",
+       "2  31.267075  71.962296  2.301536  \n",
+       "3  13.367306   4.809357  0.359785  \n",
+       "4  28.285361  26.573935  0.939494  "
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load legacy results\n",
+    "df_leg = pd.read_csv(path_leg, index_col=0)\n",
+    "df_leg['truth'] = rad_to_deg * df_leg[var]\n",
+    "df_leg['pred'] = rad_to_deg * df_leg[f\"{var}_pred\"]\n",
+    "df_leg['sigma'] = rad_to_deg * np.sqrt(df_leg[f'{var}_var'])\n",
+    "df_leg['residual'] = df_leg.pred - df_leg.truth\n",
+    "if var == 'azimuth':\n",
+    "    df_leg.loc[df_leg.pred < 0, 'pred'] = df_leg.loc[df_leg.pred < 0, 'pred'] + 360.\n",
+    "    df_leg['residual'] = df_leg.residual.apply(wrap_to_minus_180_to_180)\n",
+    "df_leg['pull'] = df_leg.residual / df_leg.sigma\n",
+    "df_leg.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7eff47300250>"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEGCAYAAABsLkJ6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAhwElEQVR4nO3de5xU5Z3n8c/P5tJEgSCy81JbpkkEtCHQQAMxCIMiihplmEjESxSFMYmayxqzwSQa4spLnHVNXCMqiQyiUWF1jD0MRuMia4wXmosiNNOkFWbTjAJpBUUE6fa3f5zTWBRV3VXdVV2X832/Xrw49ZxL/epU9fmd53nOeY65OyIiEj1H5ToAERHJDSUAEZGIUgIQEYkoJQARkYhSAhARiaguuQ4gHccdd5yXl5fnOgwRkYKxdu3av7p7v0TzCioBlJeXs2bNmlyHISJSMMzsP5LNUxOQiEhEKQGIiESUEoCISEQVVB+AiOSXgwcP0tDQwP79+3MdSuSVlpZSVlZG165dU15HCUBE2q2hoYGePXtSXl6OmeU6nMhydxobG2loaGDAgAEpr6cmIBFpt/3799O3b18d/HPMzOjbt2/aNTElABHpEB3880N7vgclABGRiFIfgIhkTF1dXUa3N3jw4FbnNzY2MmnSJADeffddSkpK6NcvuOl19erVdOvWLem6u3fv5tFHH+Xaa68FYNWqVdx5550sX748Q9En8Z/rW59/wojsvn8MJQARKVh9+/bl9ddfB2Du3Lkcc8wx3HjjjYfmNzU10aVL4sPc7t27WbBgwaEEEEVKACJSVGbOnElpaSnr169n3Lhx9OrV67DEMHToUJYvX86cOXN46623qKysZPLkyZx//vns3buXiy66iI0bNzJq1CgeeeSR7PVxxJ/pt1UzyAIlABEpOg0NDbz88suUlJQwd+7chMvMnz+fjRs3HqpBrFq1ivXr17Np0yZOOOEExo0bx5/+9CdOP/30zgu8k6kTWESKzvTp0ykpKUl7vTFjxlBWVsZRRx1FZWUl27Zty3xweUQJQESKztFHH31oukuXLnz66aeHXrd2rXz37t0PTZeUlNDU1JSdAPOEEoCIFLXy8nLWrVsHwLp169i6dSsAPXv25MMPP8xlaDmnPgARyZi2LtvMha997WssWbKEIUOGMHbsWAYNGgQEVxCNGzeOoUOHcu6553L++efnONLOZ+6e6xhSVlVV5XogjEj+2Lx5M6eeemquwygsLVf7JLsKqAP3AST6PsxsrbtXJVpeTUAiIhGlJiARkWzIwXX96VINQEQkolQDEBHJpk4c2yddqgGIiESUagAikhHlc/4tK9vdNj9il2cm6zvIQk1CNQARKWglJSVUVlYydOhQpk+fzr59+9q9rZkzZ/LEE0+kvPyqVav46le/2u73yzXVAEQkozJ1xp5qjaJHjx6HBnS77LLLuP/++7nhhhsOzW9tSOi8kuwMP4tXE6kGICJFY/z48dTX17Nq1SrGjx/PhRdeSEVFBc3Nzfzwhz9k9OjRDBs2jAceeAAIHqZ+/fXXM3jwYM466yx27tzZ7vf+6KOPuPrqqxkzZgwjRozg6WdXAbBv3z6+/vWvU1FRwbRp0xg7diwtN7R++9vfpqqqiiFDhvCzn/3s0LZqamr4yle+wvDhwxlz/jf4cO9HTJgw4VCiAzj99NN544032h0vqAYgIkWiqamJZ555hilTpgDBuD8bN25kwIABLFy4kN69e1NTU8OBAwcYN24cZ599NuvXr6euro7a2lp27NhBRUUFV199dbvef968eZx55pksWrSI3bt3M2bkcM4aP5b7Hl1Anz59qK2tZePGjVRWVh62zrHHHktzczOTJk1iw4YNnHLKKVx88cUsXbqU0aNH80HdH+lR2p1Zs2axePFifvnLX7Jlyxb279/P8OHDO7TPVAMQkYL28ccfU1lZSVVVFf3792fWrFlAMLTzgAEDAHjuuedYsmQJlZWVjB07lsbGRv785z/z4osvcskll1BSUsIJJ5zAmWee2e44nnvuOebPn09lZSUTJ05k/4FP+H/b3+Gll15ixowZQPAwmmHDhh1aZ9myZYwcOZIRI0awadMmamtrqaur4/jjj2f06NEA9Op5DF26dGH69OksX76cgwcPsmjRImbOnNnuWFukVAMwsynA3UAJ8Bt3nx83vzuwBBgFNAIXu/u2cN5NwCygGfiuuz8bs14JsAbY7u6F25MiIjkT2wcQK3ZIaHfnnnvu4ZxzzjlsmRUrVmQsDnfnySef/GxAvDba7rdu3cqdd95JTU0Nffr0YebMma0OVf25z32OyZMn8/TTT7Ns2TLWrl3b4ZjbTADhQfpeYDLQANSYWbW718YsNgt4391PNrMZwB3AxWZWAcwAhgAnAM+b2SB3bw7X+x6wGejV4U8iInkhW5eDdsQ555zDfffdx5lnnknXrl3ZsmULJ554IhMmTOCBBx7gyiuvZOfOnbzwwgtceumlR6z/1FNPsXr1am6//fZW3+Oee+7hnnvuwcxYv/HfGTH0FMaNG8eyZcs444wzqK2t5c033wTggw8+4Oijj6Z3797s2LGDZ555hokTJzJ48GDeeecdampqGD16NB/u/Ygepd3pAsyePZsLLriA8ePH06dPnw7vl1SagMYA9e7+trt/AjwOTI1bZirwUDj9BDDJggdpTgUed/cD7r4VqA+3h5mVAecDv+nwpxARacXs2bOpqKhg5MiRDB06lG9+85s0NTUxbdo0Bg4cSEVFBVdccQWnnXbaoXVuueUWqqurAXjrrbfo1av189Sbb76ZgwcPMmzYMIYMGcLN/7QAgGuvvZZdu3ZRUVHBT3/6U4YMGULv3r0ZPnw4I0aM4JRTTuHSSy9l3LhxAHTr1o2lS5fyne98h+HDhzN5xrfZf+ATAEaNGkWvXr246qqrMrNj3L3Vf8BFBM0+La+/AfwqbpmNQFnM67eA44BfAZfHlD8IXBROP0HQZDQRWN5WHO7OqFGjXETyR21tba5D6BSXXXaZ79y5M72Vtq9z377Om5qa/OOPP3Z39/r6ei8vL/cDBw6kvR139+3bt/vAgQO9ubk54aKJvg9gjSc5pubkKiAz+yqw093XmtnENpa9BrgGoH///tkPTkQkziOPPNLudfft28cZZ5zBwYMHcXcWLFhAt27d0t7OkiVL+MlPfsJdd93FUUdl5vqdVBLAduCkmNdlYVmiZRrMrAvQm6AzONm6FwIXmtl5QCnQy8wecffL49/c3RcCCyF4IEwqH0pEJF/07NmTTDzI6oorruCKK67IQESfSSWN1AADzWyAmXUj6NStjlumGrgynL4IWBlWPaqBGWbW3cwGAAOB1e5+k7uXuXt5uL2ViQ7+IiKSPW3WANy9ycyuB54luAx0kbtvMrNbCdqWqgna9h82s3rgPYKDOuFyy4BaoAm4zj+7AqjzzO3dxvw9nROHiEgeSakPwN1XACviym6Jmd4PTE+y7jxgXivbXgWsSiUOERHJnGgNBRF/pt9WzUBEUpetv6d8qaG3NShbisM1b2jY3er8YWWfTy2eDNBQECJS0HI5HHShi1YNQESyL1Nn7CnWKDp9OOj4M/2wZhB/Zj8sPL1OdsYff6bfVs0gG1QDEJGi0dnDQS9evJh/mP0Dplx2HReMH8Uv5h3qGuW5//sKp11wJRef+3fc+K2Z7PtoLxtfX8d//cdvAPD000/To0cPPvnkE/bv38954yozth9SpQQgIkWhZTjoL33pS0AwHPTdd9/Nli1bePDBBw8NB11TU8Ovf/1rtm7dylNPPXVoOOglS5bw8ssvp/2+r2/awtL75lO3eRMrVzxNH/+QE0qbuO3u3/D80vvZ/OYbTBp/Gs8tXcTXp0xga90mhpV9nj/+8Y8MHTqUmpoaXnvtNb5UOSrTu6RNagKC5FXNfOl8EpGkWoaDhqAGMGvWLF5++eUjhoPesGHDofb9PXv2ZGw46Emnj6F3r57w3mYqvljGf6z9A7v3fEjtlq2Mm3oVdA3O8k877TS6dOnCF7/4RTZv3szq1au54YYbePHFF2lubmbkmNPafrMMUwIQkYKW6+Ggu3fremi65KijaGpqxt2ZPGEsjy24/Yg+gwkTJvDMM8/QtWtXzjrrLGbOnElzczP/+IObOxxLuqKdAJKd4evyUJH2y8O/n4wMB73yX7n9pu8cMe+v3osNnw4IOnVLe8NxA/ny3w3hulvuon5fT04meFzk9u3bGTRoEOPHjz80rEO/fv1obGxkx44dnHxKRfZ3RJxoJwARiYTZs2ezbds2Ro4cibvTr18/fve73zFt2jRWrlxJRUUF/fv3P2I46KqqKi688MJgOOhjjm7lHQ7Xr18/Fi9ezCWXXMKBAwcAuO222xg0aBBjx45lx44dTJgwAYBhw4bx7rvvEoyg37ksGLKnMFRVVXm7BlVqOSNJtU0/3eVFImrz5s2ceuqpuQ4j6y6//HJ+8aOr6de3zxFNOi2Xb3b0Bq6k22m5AS2FG80SfR9mttbdqxItr6uARETa8MgjjwQH/yKjBCAiElFKACLSIYXUjFzM2vM9qBNYRNqttLSUxsZG+vbtm5NOzGKUbEiJ1rg7jY2NlJaWpvVeSgAi0m5lZWU0NDSwa9euXIeSfbvDYSL2bD6seMf7HwOw+cMeHdp8y3bibbZdCd83XmlpKWVlZWm9pxKAiLRb165dD91tW/Tmfjn8//CrA8+d828AbJt/foc2n/RaqixelagE0Iry8ItNVUd/ACIinUmdwCIiEaUaQCtSPaNPt6YgInksD4eyyBbVAEREIipSNYBkZ+pquxeRI8R1uh46fhRRjV81ABGRiIpUDSD+TF9t9yKSrmJqMYhUAkgmPhFsS+9muqzFEa+YfngikntqAhIRiahI1wCSnlHPzcz223tGr6YqEekMqgGIiERUpGsAnUVn9CKSj1QDEBGJKNUAMmBb6aXBxNz48pYpPVtYJN8kvTE0R1cB5oJqACIiEaUaQGuSDQqVbFzu+PI2BpVSX4BI7h1xNd7cnISRE0oAGZQvN5SJSKiVk7C2mmijcIKmBJBI0jP8zAwTqzt6RfJIhIZ/jqcE0B5JfjBRrkqK5LVEJ3VtHPijcKKmBNAZ0u1LyCKNNyQSKN//KBDt37wSQDpycMAWiaS2mmX0t5gRKSUAM5sC3A2UAL9x9/lx87sDS4BRQCNwsbtvC+fdBMwCmoHvuvuzZlYKvAh0D2N4wt1/lpFPlE+y3JfQEbo7WUTaTABmVgLcC0wGGoAaM6t299qYxWYB77v7yWY2A7gDuNjMKoAZwBDgBOB5MxsEHADOdPe9ZtYVeMnMnnH3VzP66SJATTpSzOouWX3Y68GPjclRJMUplRrAGKDe3d8GMLPHgalAbAKYymddnk8AvzIzC8sfd/cDwFYzqwfGuPsrwN5w+a7hP+/gZyl6OksXkUxKJQGcCPwl5nUDMDbZMu7eZGZ7gL5h+atx654Ih2oWa4GTgXvd/bX2fAAJqElHsqWuri5h+eDBgzs5Esm0nHUCu3szUGlmnweeMrOh7r4xfjkzuwa4BqB///6dG2SeiGozjg48km+K7TeZSgLYDpwU87osLEu0TIOZdQF6E3QGt7muu+82sxeAKcARCcDdFwILAaqqqtRMlKZkP9hMbKNQf/TZoH0kieT77yKVBFADDDSzAQQH7xnApXHLVANXAq8AFwEr3d3NrBp41MzuIugEHgisNrN+wMHw4N+DoIP5jox8Ismo1puS6iNbO5H8opE926fNBBC26V8PPEtwGegid99kZrcCa9y9GngQeDjs5H2PIEkQLreMoMO4CbjO3ZvN7HjgobAf4Chgmbsvz8YHbK98z9z5ItF+itw+mtubVj9xmoME6hr3FMTtw5YDfcvNXZKalPoA3H0FsCKu7JaY6f3A9CTrzgPmxZVtAEakG2w2ZKKJJAqeverkw16f88/1aW9DSVWyrT3DsUT5JEZ3AkukZTIppX3Nero1A6HuktWJvxvtu3ZRAkhTujWGYj+TSFwTKN6+gYRnizmIQyQTIpUA1NwjUuRUE0hLpBKAZE58n0CL9vQNdAYl/7ZpH0WPEkARyOQfrg4C0lG56Oxvufon2cUK27L2zpnV2U2MSgA51BlXH+TqjDybiaS1bRd7n4sUh3w50VICyLJC6zTM1yYckY5I94CbLwfobFMCKFLJ2uhBZ8lSuIITlPRPUnRik5gSQA4lvU48B3eCbpt/fkbPepL9wbWWmPJJLs8AM9E0WDDNZLpqJ6eUAPJQMVc/s33fQF7uOx3kMi7R7yXRd18oJxy5ogSQA/F3jLYohqcdFdrloZInEtR68zKZFxklgDyULBEkSxyFoK3EUIx/7G0NTLYtjW1ldMiKItjX+fYZ8i2eVCkBRFCh/lgzra0aV6YSbiYG0hPJBiWAPFLMTUNSfHQiUfiUACTy0h7FU6RIKAGI5Ej8U6xaHmpSjH1Akp+UAEQk61Sryk9KAAWkPX9EhXrW2FZHaSFf3/3sVScnvHqnfE7iAc064+DZWR3ikl+UAERSpLPYjkuaSNShnBNKAAWgPWdfxXKw0iWUybX2HQ+mfb+bbHeIp/v9FXJNrxAoAYikSc0hUiyUACSjOqstubUzyXTPGuO31XI1TrLyvFNAD5dP9btRTa9zKAFIqwqxc7DQRyJNV/wNWXk01qfkOSUAyYpstSW3dhBv71njEdt8rPXyTCjWu2iTfQftrT2pJpBdSgCSkkK4W7atAefSbdLJx8+Yjtbiz8eam3Q+JQDJCzrTa1s+9UkkSy4tMR2RYNKsPRVrc12+UQKQopf0YJLkoJTs7LjlAPxskvJ80drZfXtrNYVeG5LElACKXLp/uOk2DXT0wJDs4Hxou2kepFvdVoFIdqafzT6J9op/5sG20ktzFIm0hxKA5FShHZxbU4zNFm3VhqSwKQEUqWyfyXdWJ2ImO5874x6Ejki3qaojsnZVVh7USiR1SgDSqbI51HEx1SYKnb6LwqAEIJKiYmji0eWfEksJQDpFpg88usY9P2nfFxYlAJECoWYVyTQlADlMvh9kdIYpkjlKACJ5Lt0b00RSpQQggM6sRaLoqFQWMrMpZlZnZvVmNifB/O5mtjSc/5qZlcfMuyksrzOzc8Kyk8zsBTOrNbNNZva9jH0iERFJSZs1ADMrAe4FJgMNQI2ZVbt7bcxis4D33f1kM5sB3AFcbGYVwAxgCHAC8LyZDQKagB+4+zoz6wmsNbM/xG1TRFKQzvMPMjZkthSFVGoAY4B6d3/b3T8BHgemxi0zFXgonH4CmGRmFpY/7u4H3H0rUA+Mcfd33H0dgLt/CGwGTuz4xxERkVSl0gdwIvCXmNcNwNhky7h7k5ntAfqG5a/GrXvYgT5sLhoBvJZO4CJRl+7zD1JZN9m2pDil1AeQLWZ2DPAk8H13/yDJMteY2RozW7Nr167ODVBEpIilUgPYDpwU87osLEu0TIOZdQF6A42trWtmXQkO/r91939J9ubuvhBYCFBVVeUpxCsSadlor1dNoDilUgOoAQaa2QAz60bQqVsdt0w1cGU4fRGw0t09LJ8RXiU0ABgIrA77Bx4ENrv7XZn4ICIikp42awBhm/71BPeblACL3H2Tmd0KrHH3aoKD+cNmVg+8R5AkCJdbBtQSXPlznbs3m9npwDeAN83s9fCtfuzuKzL8+USkA3T1T3FL6Uaw8MC8Iq7slpjp/cD0JOvOA+bFlb0EWLrBiohI5uS0E1hERHJHCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKJSSgBmNsXM6sys3szmJJjf3cyWhvNfM7PymHk3heV1ZnZOTPkiM9tpZhsz8klERCQtbSYAMysB7gXOBSqAS8ysIm6xWcD77n4y8AvgjnDdCmAGMASYAiwItwewOCwTEZEcSKUGMAaod/e33f0T4HFgatwyU4GHwukngElmZmH54+5+wN23AvXh9nD3F4H3MvAZRESkHVJJACcCf4l53RCWJVzG3ZuAPUDfFNdtlZldY2ZrzGzNrl270llVRERakfedwO6+0N2r3L2qX79+uQ5HRKRopJIAtgMnxbwuC8sSLmNmXYDeQGOK64qISA6kkgBqgIFmNsDMuhF06lbHLVMNXBlOXwSsdHcPy2eEVwkNAAYCqzMTuoiIdESbCSBs078eeBbYDCxz901mdquZXRgu9iDQ18zqgRuAOeG6m4BlQC3we+A6d28GMLPHgFeAwWbWYGazMvvRRESkNV1SWcjdVwAr4spuiZneD0xPsu48YF6C8kvSilRERDIq7zuBRUQkO5QAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkopQAREQiSglARCSilABERCJKCUBEJKKUAEREIkoJQEQkolJKAGY2xczqzKzezOYkmN/dzJaG818zs/KYeTeF5XVmdk6q2xQRkexqMwGYWQlwL3AuUAFcYmYVcYvNAt5395OBXwB3hOtWADOAIcAUYIGZlaS4TRERyaJUagBjgHp3f9vdPwEeB6bGLTMVeCicfgKYZGYWlj/u7gfcfStQH24vlW2KiEgWdUlhmROBv8S8bgDGJlvG3ZvMbA/QNyx/NW7dE8PptrYJgJldA1wTvtxrZnUpxJzIcfz8lL+2c93OdBygODOrUGJVnJlVKHFCKrH+3Nq77b9NNiOVBJBT7r4QWNjR7ZjZGnevykBIWaU4M69QYlWcmVUocULuYk2lCWg7cFLM67KwLOEyZtYF6A00trJuKtsUEZEsSiUB1AADzWyAmXUj6NStjlumGrgynL4IWOnuHpbPCK8SGgAMBFanuE0REcmiNpuAwjb964FngRJgkbtvMrNbgTXuXg08CDxsZvXAewQHdMLllgG1QBNwnbs3AyTaZuY/3mE63IzUSRRn5hVKrIozswolTshRrBacqIuISNToTmARkYhSAhARiaiiTwD5PuSEmW0zszfN7HUzWxOWHWtmfzCzP4f/98lBXIvMbKeZbYwpSxiXBf5XuI83mNnIHMc518y2h/v0dTM7L2ZewqFJOiHOk8zsBTOrNbNNZva9sDyv9mkrcebjPi01s9Vm9kYY68/D8gHhkDT14RA13cLypEPW5CjOxWa2NWafVoblnffdu3vR/iPoYH4L+ALQDXgDqMh1XHExbgOOiyv7J2BOOD0HuCMHcU0ARgIb24oLOA94BjDgy8BrOY5zLnBjgmUrwt9Ad2BA+Nso6aQ4jwdGhtM9gS1hPHm1T1uJMx/3qQHHhNNdgdfCfbUMmBGW3w98O5y+Frg/nJ4BLM1xnIuBixIs32nffbHXAAp1yInYoTUeAv6+swNw9xcJruiKlSyuqcASD7wKfN7Mjs9hnMkkG5ok69z9HXdfF05/CGwmuCs+r/ZpK3Emk8t96u6+N3zZNfznwJkEQ9LAkfs00ZA1uYozmU777os9ASQaxqK1H3MuOPCcma21YNgLgL9x93fC6XeBv8lNaEdIFlc+7ufrw+rzopgmtLyIM2x6GEFwJpi3+zQuTsjDfWrB4JKvAzuBPxDUQHa7e1OCeA4bsgZoGbKm0+N095Z9Oi/cp78ws+7xcYaytk+LPQEUgtPdfSTByKjXmdmE2Jke1Anz7lrdfI0rdB/wRaASeAf4nzmNJoaZHQM8CXzf3T+InZdP+zRBnHm5T9292d0rCUYTGAOcktuIEouP08yGAjcRxDsaOBb4UWfHVewJIO+HnHD37eH/O4GnCH7EO1qqfOH/O3MX4WGSxZVX+9ndd4R/cJ8Cv+azJomcxmlmXQkOqr91938Ji/NunyaKM1/3aQt33w28AJxG0GTScpNrbDzJhqzJRZxTwuY2d/cDwD+Tg31a7Akgr4ecMLOjzaxnyzRwNrCRw4fWuBJ4OjcRHiFZXNXAFeHVC18G9sQ0a3S6uPbSaQT7FJIPTdIZMRnBHfOb3f2umFl5tU+TxZmn+7SfmX0+nO4BTCbos3iBYEgaOHKfJhqyJhdx/ntM4jeCforYfdo53322epfz5R9Bj/oWgrbBn+Q6nrjYvkBwBcUbwKaW+AjaJf8P8GfgeeDYHMT2GEFV/yBBG+SsZHERXK1wb7iP3wSqchznw2EcGwj+mI6PWf4nYZx1wLmdGOfpBM07G4DXw3/n5ds+bSXOfNynw4D1YUwbgVvC8i8QJKF64H8D3cPy0vB1fTj/CzmOc2W4TzcCj/DZlUKd9t1rKAgRkYgq9iYgERFJQglARCSilABERCJKCUBEJKKUAEREIkoJQIqemf3GzCoytK0fx0yXW8wopK2s0zLq47eSzN+bqLwdsV0cjiC5PBPbk+KnBCBFz91nu3tthjb347YXSeiH7n5/hmJIyN2XArOz+R5SXJQApCCZ2e/CAfQ2tQyiZ2YXxoytXmdmW8PyVWZWFU7vNbP/Ea73vJmNCee/bWYXhsvMNLNfxbzXcjObaGbzgR7h9n8bzi4xs1+H23suvNOzrdgHmNkrFjwH4ra4eT80s5pwgLCfx5TfHH6ml8zsMTO7saP7UEQJQArV1e4+CqgCvmtmfd292t0rPRh06w3gzgTrHU0wBMAQ4EPgNoJb86cBt7b2hu4+B/g4fI/LwuKBwL3h9nYDX0sh9ruB+9z9SwR3MQNgZmeH2xtDMOjaKDObYGajw+0OJxg0sCqF9xBpU5e2FxHJS981s2nh9EkEB85GADP7bwQH6nsTrPcJ8Ptw+k3ggLsfNLM3gfJ2xLHV3V8Pp9emuI1xfJYoHgbuCKfPDv+tD18fQ/C5egJPu/t+YL+Z/Ws74hQ5ghKAFBwzmwicBZzm7vvMbBXBOC+Y2VnAdIInhSVy0D8b/+RT4ACAu38aM4JkE4fXjktbCedAzHQz0GYTUCjRGCwG3O7uDxxWaPb9FLcpkhY1AUkh6g28Hx78TyF4bB5m9rcEg2hNd/ePO7D9bUClmR1lZidx+BOuDobDJXfEnwhGpgW4LKb8WeDqcCx+zOxEM/sv4fIXWPBs2WOAr3bw/UUA1QCkMP0e+JaZbSYYgfLVsHwmweiavwtG2OU/3f28hFto3Z+ArUAtwfDC62LmLQQ2mNk6glEw2+N7wKNm9iNihvp29+fM7FTglTD+vcDl7l5jZtUEo0nuIGi62gPQcmlptq8wkuKk0UBFsszMFgPL3f2JtpZtZRvHuPteM/sc8CJwjYfP7o1bbiLBw9tVS5A2qQlIJPv2AP892Y1gKVpowTNl1wFPJjn4XwwsAN7vwPtIhKgGICISUaoBiIhElBKAiEhEKQGIiESUEoCISEQpAYiIRNT/BwvtYvSVk2E7AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Distribution\n",
+    "bins = np.linspace(vmin, vmax, nb_bins + 1)\n",
+    "plt.hist(df_leg.truth, bins=bins, density=1, alpha=0.3, color='gray', label=f'Truth')\n",
+    "plt.hist(df_leg.pred,  bins=bins, density=1, histtype='step', lw=2, label='Pred., legacy')\n",
+    "plt.hist(df_new.pred,  bins=bins, density=1, histtype='step', lw=2, label='Pred., new')\n",
+    "plt.xlabel(f\"{var} [deg.]\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7eff47128fd0>"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEGCAYAAABsLkJ6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAhn0lEQVR4nO3de5wU5Z3v8c/P4TIqlyjO5iW3QI4IDhcHGECCchBBMRo5nEDEmAgKSxI1l2NigslZQ9zwErMejZuISiKraFQ4ukaW1eh6lDXGCyOiCIODg5B1jAGdCIoKMuPv/FE1Y9PTPd0z0z19qe/79eJF9VOX/nV1T/3qeZ6qp8zdERGR6Dki1wGIiEhuKAGIiESUEoCISEQpAYiIRJQSgIhIRHXJdQBtcdxxx/mgQYNyHYaISMHYuHHjO+5elmheQSWAQYMG8cILL+Q6DBGRgmFmf042T01AIiIRpQQgIhJRSgAiIhFVUH0AIpJfDh06RF1dHQcOHMh1KJFXWlpK//796dq1a9rrKAGISLvV1dXRs2dPBg0ahJnlOpzIcnfq6+upq6tj8ODBaa+nJiARabcDBw7Qp08fHfxzzMzo06dPm2tiSgAi0iE6+OeH9nwPSgAiIhGlPgARyZiampqMbm/o0KGtzq+vr+eMM84A4K9//SslJSWUlQU3vW7YsIFu3bolXXfv3r3cc889XHrppQCsX7+e66+/nnXr1mUm+L9san1+39GZeZ8OUAIQkYLVp08fXnrpJQCWLFlCjx49+MEPftA8v6GhgS5dEh/m9u7dy/Lly5sTQBQpAYhIUZk/fz6lpaVs2rSJSZMm0atXr8MSw4gRI1i3bh2LFy9mx44dVFRUMH36dM455xz279/P7Nmz2bJlC2PHjuXuu+/ueB9H/Jl+qppBJ1ICEJGiU1dXxzPPPENJSQlLlixJuMyyZcvYsmVLcw1i/fr1bNq0ia1bt9K3b18mTZrEn/70J0499dTOC7yTKQGISNGZM2cOJSUlbV5v/Pjx9O/fH4CKigp27dqVvQSQrCbQiX0DugpIRIrO0Ucf3TzdpUsXPvnkk+bXrV0r37179+bpkpISGhoashNgnlANQESK2qBBg5qv7HnxxRfZuXMnAD179uT999/v/ICSneHnoG9ACUBEMibVZZu58OUvf5lVq1YxfPhwJkyYwIknnggEVxBNmjSJESNGcPbZZ3POOefkONLOZ+6e6xjSVllZ6XogjEj+2LZtGyeddFKuw8hPTWf06bbpt3X5BBJ9H2a20d0rEy2vPgARkYhSAhARiSglABGRiFICEBGJKF0FJCKSTzrxBjElABHJiEGL/z0r2921LHqXZ3YWNQGJSEErKSmhoqKCESNGMGfOHD788MN2b2v+/Pncf//9aS+/fv16zj333Ha/32H6jk78L4tUAxCRjMrUGXu6NYojjzyyeUC3Cy+8kFtvvZUrrriieX5rQ0JHnWoAIlI0TjvtNGpra1m/fj2nnXYa5513HuXl5TQ2NnLllVcybtw4Ro0axW233QYED1O//PLLGTp0KNOmTWPPnj3tfu8PPviASy65hPHjxzN69GgeenQ9AB9++CFf+cpXKC8vZ9asWUyYMIGmG1q/9a1vUVlZyfDhw/npT3/avK2qqiq+8IUvcPLJJzP+nK/z/v4PmDx5cnOiAzj11FN5+eWX2x0vqAYgIkWioaGBRx55hBkzZgDBuD9btmxh8ODBrFixgt69e1NVVcXBgweZNGkSZ555Jps2baKmpobq6mp2795NeXk5l1xySbvef+nSpUydOpWVK1eyd+9exo85mWmnTeCWe5ZzzDHHUF1dzZYtW6ioqDhsnWOPPZbGxkbOOOMMNm/ezLBhwzj//PNZvXo148aN472aP3JkaXcWLFjAHXfcwS9/+Uu2b9/OgQMHOPnkkzu0z1QDEJGC9tFHH1FRUUFlZSUDBw5kwYIFQDC08+DBgwF47LHHWLVqFRUVFUyYMIH6+npee+01nnrqKS644AJKSkro27cvU6dObXccjz32GMuWLaOiooIpU6Zw4ODH/Nebb/H0008zd+5cIHgYzahRo5rXWbNmDWPGjGH06NFs3bqV6upqampqOP744xk3bhwAvXr2oEuXLsyZM4d169Zx6NAhVq5cyfz589sdaxPVAESkoMX2AcSKHRLa3fnVr37FWWedddgyDz/8cMbicHceeOCBTwfESzG6586dO7n++uupqqrimGOOYf78+a0OVX3UUUcxffp0HnroIdasWcPGjRs7HLMSgIhkVLYuB+2Is846i1tuuYWpU6fStWtXtm/fTr9+/Zg8eTK33XYb8+bNY8+ePTz55JN89atfbbH+gw8+yIYNG7j22mtbzHvvwCE21+1l9MT/zk+vvZ6r/vEXmBmN1a8yesQwJk2axJo1azj99NOprq7mlVdeCdZ77z2OPvpoevfuze7du3nkkUeYMmUKQ4cO5a233qKqqopx48bx/v4POLK0O12AhQsX8qUvfYnTTjuNY445psP7RQlARIrewoUL2bVrF2PGjMHdKSsr4/e//z2zZs3iiSeeoLy8nIEDBzJx4sTmda6++moqKys577zz2LFjB7169Wr1PRZ990p+8bOrmD19Ep+4c9KA41i36p+59NJLmTdvHuXl5QwbNozhw4fTu3dvhgwZwujRoxk2bBgDBgxg0qRJAHTr1o3Vq1fz7W9/m48++ogjSz7h8dW30gMYO3YsvXr14uKLL87IftFw0CLSblEZDvprX/saN954I2VlZS3mba7bC8Co/p85fEbYBNT42VEcOnSI0tJSduzYwbRp06ipqaFbt27pvXnMMNF/+ctfmDJlCq+++ipHHNGyC7etw0GrBiAiksLdd9/d7nU//PBDTj/9dA4dOoS7s3z58vQP/jFWrVrFT37yE2644YaEB//2UAIQEcminj17komWi4suuoiLLrooAxF9KhoJYEnvFPP3dU4cIiJ5JK16hJnNMLMaM6s1s8UJ5nc3s9Xh/OfNbFDMvKvC8hozOytuvRIz22Rm6zr8SUREpE1S1gDMrAS4GZgO1AFVZrbW3atjFlsAvOvuJ5jZXOA64HwzKwfmAsOBvsDjZnaiuzeG630X2Aa03r2eKfFn+qlqBiIiRSydJqDxQK27vw5gZvcBM4HYBDATWBJO3w/82swsLL/P3Q8CO82sNtzes2bWHzgHWApcgYgUtmydUKmJNmvSSQD9gDdiXtcBE5It4+4NZrYP6BOWPxe3br9w+pfAD4Gerb25mS0CFgEMHDgwjXBFJEpKSkoYOXIkDQ0NnHTSSdx5550cddRR7drW/PnzOffcc5k9e3bLmUnu7B3V3JCe3tDNTZeNJtPictIsykknsJmdC+xx941mNqW1Zd19BbACgvsAsh+diHRIps7Y06xRaDjo9kunE/hNYEDM6/5hWcJlzKwL0Buob2XdScB5ZrYLuA+Yambtv9BWRIROGg465mEtdzz2Mv9z4feZceFlDBkyhB/+8IfNiz32n88y8UvzGDNmDHPmzGH//v1UVVXxv/7+6wDs3PifTBhyPMP+7ihOPK6UL06qyMYuaVU6CaAKGGJmg82sG0Gn7tq4ZdYC88Lp2cATHtxivBaYG14lNBgYAmxw96vcvb+7Dwq394S7fy0Dn0dEIqppOOiRI0cCwXDQN910E9u3b+f2229vHg66qqqK3/zmN+zcuZMHH3yweTjoVatW8cwzz7T5fV/aup3VtyzjlVdeYfXq1bzxxhu88847/Pym3/L46lt58cUXqays5IYbbmD06NHUVAdjAf3xj39kxIgRVFVV8fzzzzOyYmxG90c6UtaLwjb9y4FHgRJgpbtvNbNrgBfcfS1wO3BX2Mn7N4KDOuFyawg6jBuAy2KuABIR6bCm4aAhqAEsWLCAZ555psVw0Js3b25+3OO+ffsyNhz0GaeOp3evnlBaSnl5OX/+85/Zu3cv1dt3MmnmxdD1SD7++GMmTpxIly5dGPC5wbz+Wg0bNmzgiiuu4KmnnqKxsZEx4yemfrMMS6thzN0fBh6OK7s6ZvoAMCfJuksJrvRJtu31wPp04hARiZfr4aC7d+vaPF1SUkJDQwPuzvTJE7h3+bUtnus7ZvwXePrJx+natSvTpk1j/vz5NDY28vff/4cOx9JW6hmB5J1NuvxMpO3y8P6ajAwH/cS/ce1V307r/U455RQu++Yianf+Fyf0Hc0HH3zAm2++yYknnsiYCRP539/7Jgsunk9ZWRn19fXs3r2bE4aVZ/pjp6QngolI0Vu4cCHl5eWMGTOGESNG8I1vfIOGhgZmzZrFkCFDKC8v56KLLmoxHPTatUF3544dO+jV4+hkm2+hrKyMO25cwgWX/ZhRo0YxceJEXn31VQBGVoyl/p23mTx5MgCjRo1i5MiRBLdOda5oDAfddEaS7hl9W5cXiahIDQf9o0so63NMiyad2OGaE5Vv/mRwwm3GX++faljpFttPoK3DQasGICKSwt133x0c/IuM+gBERLKoM+/sbSvVAESkQwqpGbmYted7UA1ARNqttLSU+vp6+vTpk5NOzGIUP1bQqDRO092d+vp6SktL2/ReSgAi0m79+/enrq6Ot99+O9ehZN/ecJiIfds6Vp7E7nc/Sli+zd5OazulpaX0798/rfdqogQgIu3WtWvX5rtti96SU8L/458r0sbyJJJeS5XFqxLVByAiElFKACIiEaUEICISUeoDEBHJhDwcAykV1QBERCIqUjWAQYv/PWH5rmXn5EUcTTo7HhFpv0EH7gEK8+9WNQARkYiKVA0gPkOnOhPPtnyLR0SiRTUAEZGIilQNoKPUdi8SAQV4NU97qQYgIhJRqgG0Q7K2+3y5ykhEMiACTwRUAmiFOmVFpJgpAWRAsjN8JRARyWdKAK3IVNONEoGI5CMlgCzaVfrVFEsUfxujSE6lc0VPBNr6k1ECEOmoVAeZCB9gClkULupQAugMLZ4UFJ3rjEXyQqIkrL9DJYB8FIUzj6KkRF9U2nq5dyFSAhCRaItwolYCyCP5eDmphr8QCRTjb10JQKSzqdM4PyTZz00nPbs6MZRcUQKQtGjoaik2+g0rAWRGhNsQpQPUaSw5pgQgGaU+Ayk0Uf5NKgG0hdpuRaSIpJUAzGwGcBNQAvzW3ZfFze8OrALGAvXA+e6+K5x3FbAAaAS+4+6Pmlkp8BTQPYzhfnf/aUY+USYVQJW8rWfcnXWGrj4DkfyXMgGYWQlwMzAdqAOqzGytu1fHLLYAeNfdTzCzucB1wPlmVg7MBYYDfYHHzexE4CAw1d33m1lX4Gkze8Tdn8vop8sWnek304FdsqWmpiZh+dChQzs5kuKVTg1gPFDr7q8DmNl9wEwgNgHMBJaE0/cDvzYzC8vvc/eDwE4zqwXGu/uzwP5w+a7hP+/gZ8mYQQfuAQqrbbCjZ/o6kItETzoJoB/wRszrOmBCsmXcvcHM9gF9wvLn4tbtB801i43ACcDN7v58ez6A5EYhJUfpGJ2JF6+cdQK7eyNQYWafAR40sxHuviV+OTNbBCwCGDhwYOcGKc0SHQSyfQDQgUfyTbH9JtNJAG8CA2Je9w/LEi1TZ2ZdgN4EncEp13X3vWb2JDADaJEA3H0FsAKgsrIyb5qJCkWyH6xkXvy+LsxDgmRSvieMdBJAFTDEzAYTHLznAvFPOlkLzAOeBWYDT7i7m9la4B4zu4GgE3gIsMHMyoBD4cH/SIIO5usy8onaQe3fRU6X74oklDIBhG36lwOPElwGutLdt5rZNcAL7r4WuB24K+zk/RtBkiBcbg1Bh3EDcJm7N5rZ8cCdYT/AEcAad1+XjQ/YEblo9igk7Tm70T4VyR9p9QG4+8PAw3FlV8dMHwDmJFl3KbA0rmwzMLqtwWbarmXnqImkk531L7UJSms7p1NZQy9IAlE+KdGdwG2UyzY9NVVlR7YPAPHf267SjG1apEOUADIk3zt7ci1ZbStxjSB/JUwWOYhDJBMilQAKtblH19wXthbf35KchCHSQqQSQLEq1MTW2XSZZusK/XfUWu2sUJpPO7uGqQSQQ/nY+VQIfyitHahyvf9EzaGFRAmgyOWijb3QziRzemWStEnwXSX/TT968QkJy5N9l7n6rebL34gSQJYVSqdhvl0Sm6omkuwPPS/pctOM2VUafw/q4WrYkLi8jb/tfPpbyCYlgCLV2gEyH6viuWx6it9XTTWCqBwE8tKS3u06UYqvzemS29YpAUheS3ZwLgTJhhVvSna7kqyXib6hou8n0U19GaEEkGeidtb56MUnJD0gtbYvkieC2hZJI9eHu6h9p5lUc8HhTTpN3/uuJMu3qPnem/mYiokSgORcoRwgh947Pmfvnckrawplf7dHLr+jQqQEEEGFfABorW8j081Dak/OX/l2T0eh/k0pAeRQsrOV+Gqv5JdkzRIUUP9EsdHfTPsoAUhkpHtGn7SWofbkwxTqWa98SgkgB5Kdraj9srAV1L0JIigBSArtTUr5WCVP9woRJWKJCiUAyUupDsL5mGCkdRojKP8oARSAdM5Is31ATHf7TbEWUgd3urE29SE8mvWIoqVQhkspRkoAktfiD8LF1DyjJ4Ulv3S3aV8U0p3fhUgJoIAkOnvOtwNiIXVw52NtRKQzKQFI0cn3G7iSDn+xpG3baS2pDiW/ElyyWJu+mxaxhh30urIqu5QARPJMIfWfZEo+1hCjQAlAOlU2/9BTjRWfTzLZ8VlI/SSFFGsUKAHkofb8UUTxrDFXstUx2TR8dIvRTIv4IJnsM0vnUAIocvmSGDrz/ZT0Aq0lDu0jASWAvNKeP8pCuuqm0OksVYqNEkCRUmKIrtZOJPT9SywlABFps1T9IKotFQYlAClIUTyTzff7G9KhO3vzixKAiLRb/Jm+DvCFRQkgovLl6qC2yvf4MiHZmX4xPPBcTUP5RQlApEBEsdlLsksJIGJ0dVD+0qMopbMpAYjkuWRJuzOeT5ByEDeKv0mumCkBiEjGFcMVS1GgBCAiKWkQt+KUVgIwsxnATUAJ8Ft3XxY3vzuwChgL1APnu/uucN5VwAKgEfiOuz9qZgPC5T8LOLDC3W/KyCcSkU4TnwhSje8v+eWIVAuYWQlwM3A2UA5cYGblcYstAN519xOAG4HrwnXLgbnAcGAGsDzcXgPwfXcvB04BLkuwTRERyaJ0agDjgVp3fx3AzO4DZgLVMcvM5NPnGd0P/NrMLCy/z90PAjvNrBYY7+7PAm8BuPv7ZrYN6Be3TRHJU1EcuroYpZMA+gFvxLyuAyYkW8bdG8xsH9AnLH8ubt1+sSua2SBgNPB8ojc3s0XAIoCBAwemEa6IpKIDtUAaTUDZZGY9gAeA77n7e4mWcfcV7l7p7pVlZWWdG6CISBFLpwbwJjAg5nX/sCzRMnVm1gXoTdAZnHRdM+tKcPD/nbv/a7uiF5E2icJQGpK+dBJAFTDEzAYTHLznAvEPX10LzAOeBWYDT7i7m9la4B4zuwHoCwwBNoT9A7cD29z9hsx8FMkENQ1IJuh3VBhSJoCwTf9yghsOS4CV7r7VzK4BXnD3tQQH87vCTt6/ESQJwuXWEHTuNgCXuXujmZ0KfB14xcxeCt/qx+7+cIY/n4iIJJHWfQDhgfnhuLKrY6YPAHOSrLsUWBpX9jRgbQ1WskdNA5IJ+h0Vlpx2AouISO4oAYiIRJQSgIhIRCkBiIhElBKAiEhEKQGIiESUEoCISEQpAYiIRJQSgIhIRCkBiIhElJ4JLFLg4h/A3iT+YS0i8VQDEBGJKNUARApUsjP8ZDWCVPNa26YUJ9UAREQiSjUAkQiKP9NPVjNIVWOQwqYagIhIRKkGICIpqW+gOKkGICISUUoAIiIRpSYgEWmmTt9oUQ1ARCSiVAMQEXXyRpRqACIiEaUEICISUUoAIiIRpQQgIhJRSgAiIhGlBCAiElG6DFSkSOmmLklFNQARkYhSDUCkyOimLkmXagAiIhGlBCAiElFKACIiEaUEICISUWklADObYWY1ZlZrZosTzO9uZqvD+c+b2aCYeVeF5TVmdlZM+Uoz22NmWzLySUREpE1SJgAzKwFuBs4GyoELzKw8brEFwLvufgJwI3BduG45MBcYDswAlofbA7gjLBMRkRxIpwYwHqh199fd/WPgPmBm3DIzgTvD6fuBM8zMwvL73P2gu+8EasPt4e5PAX/LwGcQEZF2SCcB9APeiHldF5YlXMbdG4B9QJ80122VmS0ysxfM7IW33367LauKiEgr8r4T2N1XuHulu1eWlZXlOhwRkaKRTgJ4ExgQ87p/WJZwGTPrAvQG6tNcV0REciCdBFAFDDGzwWbWjaBTd23cMmuBeeH0bOAJd/ewfG54ldBgYAiwITOhi4hIR6RMAGGb/uXAo8A2YI27bzWza8zsvHCx24E+ZlYLXAEsDtfdCqwBqoE/AJe5eyOAmd0LPAsMNbM6M1uQ2Y8mIiKtSWswOHd/GHg4ruzqmOkDwJwk6y4FliYov6BNkYqISEblfSewiIhkhxKAiEhEKQGIiESUEoCISEQpAYiIRJQSgIhIRCkBiIhElBKAiEhEKQGIiESUEoCISEQpAYiIRJQSgIhIRCkBiIhElBKAiEhEKQGIiESUEoCISEQpAYiIRJQSgIhIRCkBiIhElBKAiEhEKQGIiESUEoCISEQpAYiIRJQSgIhIRCkBiIhElBKAiEhEKQGIiESUEoCISEQpAYiIRJQSgIhIRCkBiIhElBKAiEhEKQGIiESUEoCISEQpAYiIRJQSgIhIRKWVAMxshpnVmFmtmS1OML+7ma0O5z9vZoNi5l0VlteY2VnpblNERLIrZQIwsxLgZuBsoBy4wMzK4xZbALzr7icANwLXheuWA3OB4cAMYLmZlaS5TRERyaJ0agDjgVp3f93dPwbuA2bGLTMTuDOcvh84w8wsLL/P3Q+6+06gNtxeOtsUEZEs6pLGMv2AN2Je1wETki3j7g1mtg/oE5Y/F7duv3A61TYBMLNFwKLw5X4zq0kj5kSO42fD3mnnup3pOEBxZlahxKo4M6tQ4oR0Yv2ZtXfbn0s2I50EkFPuvgJY0dHtmNkL7l6ZgZCySnFmXqHEqjgzq1DihNzFmk4T0JvAgJjX/cOyhMuYWRegN1DfyrrpbFNERLIonQRQBQwxs8Fm1o2gU3dt3DJrgXnh9GzgCXf3sHxueJXQYGAIsCHNbYqISBalbAIK2/QvBx4FSoCV7r7VzK4BXnD3tcDtwF1mVgv8jeCATrjcGqAaaAAuc/dGgETbzPzHO0yHm5E6ieLMvEKJVXFmVqHECTmK1YITdRERiRrdCSwiElFKACIiEVX0CSDfh5wws11m9oqZvWRmL4Rlx5rZf5jZa+H/x+QgrpVmtsfMtsSUJYzLAv8c7uPNZjYmx3EuMbM3w336kpl9MWZewqFJOiHOAWb2pJlVm9lWM/tuWJ5X+7SVOPNxn5aa2QYzezmM9Wdh+eBwSJracIiabmF50iFrchTnHWa2M2afVoTlnffdu3vR/iPoYN4BfB7oBrwMlOc6rrgYdwHHxZX9AlgcTi8GrstBXJOBMcCWVHEBXwQeAQw4BXg+x3EuAX6QYNny8DfQHRgc/jZKOinO44Ex4XRPYHsYT17t01bizMd9akCPcLor8Hy4r9YAc8PyW4FvhdOXAreG03OB1TmO8w5gdoLlO+27L/YaQKEOORE7tMadwP/o7ADc/SmCK7piJYtrJrDKA88BnzGz43MYZzLJhibJOnd/y91fDKffB7YR3BWfV/u0lTiTyeU+dXffH77sGv5zYCrBkDTQcp8mGrImV3Em02nffbEngETDWLT2Y84FBx4zs40WDHsB8Fl3fyuc/ivw2dyE1kKyuPJxP18eVp9XxjSh5UWcYdPDaIIzwbzdp3FxQh7uUwsGl3wJ2AP8B0ENZK+7NySI57Aha4CmIWs6PU53b9qnS8N9eqOZdY+PM5S1fVrsCaAQnOruYwhGRr3MzCbHzvSgTph31+rma1yhW4D/BlQAbwH/J6fRxDCzHsADwPfc/b3Yefm0TxPEmZf71N0b3b2CYDSB8cCw3EaUWHycZjYCuIog3nHAscCPOjuuYk8AeT/khLu/Gf6/B3iQ4Ee8u6nKF/6/J3cRHiZZXHm1n919d/gH9wnwGz5tkshpnGbWleCg+jt3/9ewOO/2aaI483WfNnH3vcCTwESCJpOmm1xj40k2ZE0u4pwRNre5ux8E/oUc7NNiTwB5PeSEmR1tZj2bpoEzgS0cPrTGPOCh3ETYQrK41gIXhVcvnALsi2nW6HRx7aWzCPYpJB+apDNiMoI75re5+w0xs/JqnyaLM0/3aZmZfSacPhKYTtBn8STBkDTQcp8mGrImF3G+GpP4jaCfInafds53n63e5Xz5R9Cjvp2gbfAnuY4nLrbPE1xB8TKwtSk+gnbJ/we8BjwOHJuD2O4lqOofImiDXJAsLoKrFW4O9/ErQGWO47wrjGMzwR/T8THL/ySMswY4uxPjPJWgeWcz8FL474v5tk9biTMf9+koYFMY0xbg6rD88wRJqBb4v0D3sLw0fF0bzv98juN8ItynW4C7+fRKoU777jUUhIhIRBV7E5CIiCShBCAiElFKACIiEaUEICISUUoAIiIRpQQgRc/Mfmtm5Rna1o9jpgdZzCikrazTNOrjN5PM35+ovB2xnR+OILkuE9uT4qcEIEXP3Re6e3WGNvfj1IskdKW735qhGBJy99XAwmy+hxQXJQApSGb2+3AAva1Ng+iZ2XkxY6vXmNnOsHy9mVWG0/vN7J/C9R43s/Hh/NfN7Lxwmflm9uuY91pnZlPMbBlwZLj934WzS8zsN+H2Hgvv9EwV+2Aze9aC50D8PG7elWZWFQ4Q9rOY8n8IP9PTZnavmf2go/tQRAlACtUl7j4WqAS+Y2Z93H2tu1d4MOjWy8D1CdY7mmAIgOHA+8DPCW7NnwVc09obuvti4KPwPS4Mi4cAN4fb2wt8OY3YbwJucfeRBHcxA2BmZ4bbG08w6NpYM5tsZuPC7Z5MMGhgZRrvIZJSl9SLiOSl75jZrHB6AMGBsx7AzH5IcKC+OcF6HwN/CKdfAQ66+yEzewUY1I44drr7S+H0xjS3MYlPE8VdwHXh9Jnhv03h6x4En6sn8JC7HwAOmNm/tSNOkRaUAKTgmNkUYBow0d0/NLP1BOO8YGbTgDkETwpL5JB/Ov7JJ8BBAHf/JGYEyQYOrx2XthLOwZjpRiBlE1Ao0RgsBlzr7rcdVmj2vTS3KdImagKSQtQbeDc8+A8jeGweZvY5gkG05rj7Rx3Y/i6gwsyOMLMBHP6Eq0PhcMkd8SeCkWkBLowpfxS4JByLHzPrZ2Z/Fy7/JQueLdsDOLeD7y8CqAYghekPwDfNbBvBCJTPheXzCUbX/H0wwi5/cfcvJtxC6/4E7ASqCYYXfjFm3gpgs5m9SDAKZnt8F7jHzH5EzFDf7v6YmZ0EPBvGvx/4mrtXmdlagtEkdxM0Xe0DaLq0NNtXGElx0migIllmZncA69z9/lTLtrKNHu6+38yOAp4CFnn47N645aYQPLxdtQRJSU1AItm3D/jHZDeCpWmFBc+UfRF4IMnB/3xgOfBuB95HIkQ1ABGRiFINQEQkopQAREQiSglARCSilABERCJKCUBEJKL+P6Dq+yENfKw2AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Distribution (sliced in sigma)\n",
+    "percentile = 50.\n",
+    "threshold_sigma_leg = np.percentile(df_leg.sigma, percentile)\n",
+    "threshold_sigma_new = np.percentile(df_new.sigma, percentile)\n",
+    "\n",
+    "df_leg_precise = df_leg.query(f\"sigma < {threshold_sigma_leg}\")\n",
+    "df_new_precise = df_new.query(f\"sigma < {threshold_sigma_new}\")\n",
+    "\n",
+    "bins = np.linspace(vmin, vmax, nb_bins + 1)\n",
+    "plt.hist(df_leg.truth,        bins=bins, density=1, alpha=0.3, color='gray', label=f'Truth')\n",
+    "plt.hist(df_leg_precise.pred, bins=bins, density=1, histtype='step', lw=2, label='Pred., legacy')\n",
+    "plt.hist(df_new_precise.pred, bins=bins, density=1, histtype='step', lw=2, label='Pred., new')\n",
+    "plt.xlabel(f\"{var} [deg.]\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7eff470d2940>"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEGCAYAAACevtWaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAi5UlEQVR4nO3deXxU9f3v8ddHpAQFZNVSEQLWoigQMSoWSN2qYJVFQdnEnQeISkV/ijte4V70WheUSmm1ig80oEixYrVa4GJRsWJRVFwQUYMoiwVBy/65f8zJMElmkkkyycycvJ+Pxzwy8z3LfDKZfOY73/M9n2PujoiIhMt+6Q5ARERST8ldRCSElNxFREJIyV1EJISU3EVEQmj/dAcA0LJlS8/NzU13GCIiWWXZsmUb3b1VvGUZkdxzc3N5++230x2GiEhWMbMvEi3TsIyISAgpuYuIhJCSu4hICGXEmLtIXbZr1y6KiorYvn17ukORDJWTk0ObNm2oX79+0tsouYukWVFREY0bNyY3NxczS3c4kmHcnU2bNlFUVET79u2T3k7DMiJptn37dlq0aKHELnGZGS1atKj0Nzsld5EMoMQu5anK+0PDMiIZJHf8/BrZ75rJv6mR/UrmUs9dZMJB5d/qgEaNGqU7hIQeeOABZsyYkXD5okWLeP311xMuT/XvNnPmTPLy8qK3/fbbj+XLlwPQu3dvunbtytFHH82oUaPYs2dPme3nzZtHly5dyMvLIz8/n3/+858AbNiwgd69e6csTvXcRTJQqnraNfVNoLbs3r2bxx57jHfeeSfhOosWLaJRo0b88pe/rJWYhg0bxrBhwwBYsWIF/fv3Jy8vD4DZs2fTpEkT3J2BAwfyzDPPMHjw4BLbn3baafTt2xcz47333uP888/no48+olWrVrRu3ZolS5bQo0ePasepnrtIIHf7UyVudd1nn31G7969Oe644+jVqxcfffRRtL179+507tyZW2+9Ndoz3rZtG6eddhrdunWjc+fOzJs3L7qvGTNm0KVLF7p27cqFF17I1q1bad++Pbt27QLg+++/L/G42IIFC+jWrRv77x/ph06ZMoVOnTrRpUsXBg8ezJo1a5g2bRr3338/eXl5vPbaa3z++eecdNJJ0fhq0tNPP10ieTdp0gSIfCjt3Lkz7lh5o0aNou0//PBDiXX69+/PzJkzUxKbeu4iFSlvaGbCltqLo5aNHDmSadOmccQRR7B06VKuvPJKFixYwNixYxk7dixDhgxh2rRp0fVzcnKYO3cuTZo0YePGjXTv3p2+ffvy4YcfMnHiRF5//XVatmzJd999R+PGjTn55JOZP38+/fv3p7CwkHPPPbfMPO4lS5Zw3HHHRR9PnjyZzz//nAYNGrB582aaNm3KqFGjaNSoEddffz0Affv2ZfTo0YwYMYKpU6cm9btee+21LFy4sEz74MGDGT9+fMLtZs2aVeJDDODMM8/krbfeok+fPgwcODDudnPnzuWmm25i/fr1zJ+/79tVfn5+yj6QlNxFAmWGQiakJYyMsG3bNl5//XUGDRoUbduxYwcAb7zxBn/5y18AGDp0aDSpujs333wzixcvZr/99mPt2rV8++23LFiwgEGDBtGyZUsAmjdvDsDll1/OPffcQ//+/fnzn//MH//4xzJxrFu3jqOOOir6uEuXLgwbNoz+/fvTv3//uLEvWbKEOXPmAHDhhRdy4403Vvj73n///RWuU9rSpUs54IADOOaYY0q0v/zyy2zfvp1hw4axYMECfv3rX5fZdsCAAQwYMIDFixdz22238eqrrwJw8MEH8/XXX1c6lniU3EUSKB6aiTv+HfIDrXv37qVp06bRA4XJmDlzJhs2bGDZsmXUr1+f3Nzccudm9+jRgzVr1rBo0SL27NlTJkkCNGzYsMQ+5s+fz+LFi/nrX//KpEmTWLFiRdx9V3bqYFV67oWFhQwZMiTuspycHPr168e8efPiJvdiBQUFrF69mo0bN9KyZUu2b99Ow4YNKxV7IkruIhko3QdCmzRpQvv27XnmmWcYNGgQ7s57771H165d6d69O3PmzOGCCy6gsLAwus2WLVs4+OCDqV+/PgsXLuSLLyLVaE899VQGDBjAuHHjaNGiBd9991209z5ixAiGDh3KbbfdFjeOo446ilWrVgGRD5yvvvqKU045hZ49e1JYWMi2bdto3Lgx33//fXSbHj16UFhYyPDhw5Mev65sz33v3r3Mnj2b1157Ldq2bds2tm7dSuvWrdm9ezfz58+nV69eZbZdtWoVhx9+OGbGO++8w44dO2jRogUAn3zySdwPuapQchepQLxEuyYnDYHUoB9//JE2bdpEH48bN46ZM2cyevRoJk6cyK5duxg8eDBdu3blgQceYPjw4UyaNInevXtz0EGRbzHDhg3jnHPOoXPnzuTn53PkkUcCcPTRR3PLLbfwq1/9inr16nHsscfy+OOPR7e59dZbE/aA+/Tpw4UXXgjAnj17GD58OFu2bMHdueaaa2jatCnnnHMOAwcOZN68eTz00EM8+OCDDB06lLvvvpt+/fqV2F9eXl6lvo0ksnjxYg477DA6dOgQbfvhhx/o27cvO3bsYO/evZxyyimMGjUKIHpsYtSoUcyZM4cZM2ZQv359GjZsyKxZs6LfNBYuXMhvfpOamVLm7inZUXXk5+e7LtYhaVM8xFLq4Gh5vec1OUPjblMVK1euLDGunOl+/PFHGjZsiJlRWFjI008/XeagYrKeffZZ5s2bx5NPPplwnQEDBnDPPfdwxBFHVDXkrFFQUMC8efNo1qxZmWXx3idmtszd8+PtSz13kQTKnWs+odbCyDjLli3jqquuwt1p2rQpjz32WJX2c/XVV/O3v/2NF198sdz1Jk+ezLp160Kf3Dds2MC4cePiJvaqUHIXkUrp1asX7777brX389BDDyW1XseOHenYsWO1ny/TtWrVKuEMoKrQSUwiIiGk5C4iEkIalhGphkQHXVWFUdJNyV0kk9TUyVEhLpMg8Sm5i1RD6R56uk8+Eimm5C51RzaVDEhVTzvJ39nMGDduHL/73e8AuPfee9m2bRsTJkxITRxE6sRcccUVvPDCC3GXb968maeeeoorr7wy7vKLL76Ys88+O2ExrsraunVriTNIi4qKGD58OA888ADTpk1j6tSp1KtXj0aNGjF9+nQ6depUZh+XXnopL7zwAgcffDDvv/9+tP3666/nrLPO4tRTT01JrFWR1AFVM7vWzD4ws/fN7GkzyzGz9ma21MxWmdksM/tJsG6D4PGqYHlujf4GIlJtDRo04LnnnmPjxo019hz33XcfV1xxRcLlmzdv5ve//32NPX9pjRs3Zvny5dFbu3btOPfcc4FIQbQVK1awfPlybrjhBsaNGxd3HxdffDEvvfRSmfarr76ayZMn12j8FakwuZvZocA1QL67HwPUAwYDdwP3u/vPgf8AlwWbXAb8J2i/P1hPJHNM2FLipvrtsP/++zNy5Mi4NVY2bNjAeeedx/HHH8/xxx/PkiVLAOjcuTObN2/G3WnRokX0akkjRozglVdeKbOfOXPmRK809MEHH3DCCSeQl5dHly5d+PTTTxk/fjyfffYZeXl5/M///A/uzlVXXUXHjh05/fTTWb9+fY39/p988gnr16+P9uSL67JD2ZrrsQoKCqJ1cmK1a9eOTZs28c0339RMwElIdlhmf6Chme0CDgDWAacCwTnYPEHknL1HgH7sO3/vWeBhMzPPhDoHImhcPJExY8bQpUsXbrjhhhLtY8eO5dprr6Vnz558+eWXnHnmmaxcuZIePXqwZMkS2rVrR4cOHXjttdcYMWIEb7zxBo888kiJfXz++ec0a9aMBg0aAJFaK2PHjmXYsGHs3LmTPXv2MHnyZN5///1o7ZfnnnuOjz/+mA8//JBvv/2WTp06cemll5b7OyxcuJBrr722TPsBBxxQ7qX4CgsLueCCC0ok8alTp3Lfffexc+dOFixYUO7zxtOtWzeWLFnCeeedV+ltU6HC5O7ua83sXuBL4L/A34FlwGZ33x2sVgQcGtw/FPgq2Ha3mW0BWgAlvu+Z2UhgJEDbtm2r/5uIpEOpMe19BcWyb3ZKkyZNGDFiBFOmTClRdvbVV1/lww8/jD7+/vvv2bZtG7169WLx4sW0a9eO0aNHM336dNauXUuzZs048MADS+x73bp1tGrVKvr4pJNOYtKkSRQVFXHuuefGLS2wePFihgwZQr169fjZz36W1Pj1KaecUqXCYIWFhWXq24wZM4YxY8bw1FNPMXHiRJ544olK7TOVtdmrosLkbmbNiPTG2wObgWeAal/F1d2nA9MhUjisuvsTSVZWzEFP08Hf3/72t3Tr1o1LLrkk2rZ3717efPNNcnJKlsIsKChg6tSpfPnll0yaNIm5c+fy7LPPxi1zW7ou+9ChQznxxBOZP38+Z511Fn/4wx9KVFisqqr03N999112795d4opPsQYPHszo0aMrHUsqa7NXRTIHVE8HPnf3De6+C3gO6AE0NbPiD4c2wNrg/lrgMIBg+UHAppRGLZJupcbto7cs17x5c84//3weffTRaNsZZ5xRog5Mcc/4sMMOY+PGjXz66ad06NCBnj17cu+991JQUFBmv7/4xS9Ys2ZN9PHq1avp0KED11xzDf369eO9996jcePGbN26NbpOQUEBs2bNYs+ePaxbty7uxTRKK+65l76VNyTz9NNPlyk5/Omnn0bvz58/v0pFy1JZm70qkhlz/xLobmYHEBmWOQ14G1gIDAQKgYuA4pqfzweP3wiWL9B4u0iSMuAD4rrrruPhhx+OPp4yZUp0PH737t0UFBRE65OfeOKJ7NmzB4gUFLvpppvo2bNnmX0eeOCBHH744axatYqf//znzJ49myeffJL69evz05/+lJtvvpnmzZvTo0cPjjnmGPr06cM999zDggUL6NSpE23btuWkk06K7u/2228nPz+fvn37Vvv3nT17dpnKlA8//DCvvvoq9evXp1mzZtEhma+//prLL788uv6QIUNYtGgRGzdupE2bNtx5551cdtll7Nq1i1WrVpGfH7cab61Iqp67md0JXADsBv4NXE5kbL0QaB60DXf3HWaWAzwJHAt8Bwx299Xl7V/13KVWJKjbnu7nyLZ67lU1d+5cli1bxsSJE9MdSo2bO3cu77zzDnfddVfK9lkj9dzd/Q7gjlLNq4ET4qy7HRhUul1E6rYBAwawaVPdGKHdvXs31113XVpj0BmqIhnA3St9UedsdPnll6c7hFoxaFBq+7dVGdlWyV+RNMvJyWHTpk1V+geW8HN3Nm3aVGa2UkXUcxepAZUpBdymTRuKiorYsGFDTYclWSonJ6fEBcyToeQu4ZNNBcKA+vXr0759+3SHISGj5C5SA1QKWNJNyV3Cq9R0xOIEuyYNoYjUNh1QFREJISV3EZEQUnIXEQkhJXcRkRBSchcRCSHNlpHQ0vRDqcvUcxcRCSH13CW0suKKSyI1RMldpCaE6Nqqkp00LCMiEkLquYukUqIrMGVZMTPJfuq5i4iEkJK7iEgIaVhGspeGOkQSUs9dRCSE1HOX7Ke67SJlqOcuIhJC6rmL1KLKXDhbpDrUcxcRCSH13EVqkS6cLbVFyV2kNqnmjNQSJXfJeur9ipSl5C5SG1RzRmqZkrtkPc00ESlLs2VEREJIyV1EJISU3EVEQkjJXUQkhJTcRURCSMldRCSElNxFREJIyV1EJISSSu5m1tTMnjWzj8xspZmdZGbNzewVM/s0+NksWNfMbIqZrTKz98ysW83+CiIiUlqyPfcHgZfc/UigK7ASGA/8w92PAP4RPAboAxwR3EYCj6Q0YhERqVCF5QfM7CCgALgYwN13AjvNrB9wcrDaE8Ai4EagHzDD3R14M+j1t3b3dSmPXuoG1V8RqbRkeu7tgQ3An83s32b2JzM7EDgkJmF/AxwS3D8U+Cpm+6KgrQQzG2lmb5vZ2xs2bKj6byAiImUkUzhsf6AbcLW7LzWzB9k3BAOAu7uZeWWe2N2nA9MB8vPzK7Wt1FG6ELZI0pLpuRcBRe6+NHj8LJFk/62ZtQYIfq4Plq8FDovZvk3QJiIitaTCnru7f2NmX5lZR3f/GDgN+DC4XQRMDn7OCzZ5HrjKzAqBE4EtGm+XVNBFOUSSl2w996uBmWb2E2A1cAmRXv9sM7sM+AI4P1j3ReAsYBXwY7CuiJQn0UHjRBf5EKlAUsnd3ZcD+XEWnRZnXQfGVC8sqZMqmBWji3KIJE9XYhJJo9ztTwFxPrg0/VOqScldMk8dnBVT+njCmpw0BSKhodoyIiIhpJ67SBolPI4woVbDkBBSz11EJISU3EVEQkjDMiIZLNGJW5oWKhVRz11EJITUcxfJYKV76CrBIMlScpeMowQmUn0alhERCSH13CXj6GChSPWp5y4iEkJK7iIiIaRhGZFMVqo65L6CYqrzLuVTz11EJITUcxfJRImuwKQ675Ik9dxFREJIyV1EJISU3EVEQkhj7lLrElY61KXlRFJGPXcRkRBSz13SpkyZgQlpCUMklNRzFxEJISV3EZEQUnIXEQkhJXcRkRBSchcRCSEldxGRENJUSKl1a3KGRu5MSGsYIqGmnruISAip5y7pk6isrYhUm3ruIiIhpOQuIhJCSu4iIiGkMXeREEhURrlYmSJtEnpK7iLZqNS1VItr4edufyoNwUgmUnIXCZHoOQRlaGZSXZN0cjezesDbwFp3P9vM2gOFQAtgGXChu+80swbADOA4YBNwgbuvSXnkkvF0xaXUS9QzT5zUpa6qTM99LLASaBI8vhu4390LzWwacBnwSPDzP+7+czMbHKx3QQpjliyhhJN6icfOE/TMSw3fSN2R1GwZM2sD/Ab4U/DYgFOBZ4NVngD6B/f7BY8Jlp8WrC8iIrUk2Z77A8ANQOPgcQtgs7vvDh4XAYcG9w8FvgJw991mtiVYf2PsDs1sJDASoG3btlUMX7KCzkRNv0Q9eP1tQqvCnruZnQ2sd/dlqXxid5/u7vnunt+qVatU7lpEpM5LpufeA+hrZmcBOUTG3B8EmprZ/kHvvQ2wNlh/LXAYUGRm+wMHETmwKiK1rPgAbNmLkWssPuwq7Lm7+03u3sbdc4HBwAJ3HwYsBAYGq10EzAvuPx88Jli+wN09pVGLiEi5qlN+4EZgnJmtIjKm/mjQ/ijQImgfB4yvXogiIlJZlTqJyd0XAYuC+6uBE+Kssx0YlILYRESkilQ4TEQkhFR+QKQOKH22sM4SDj/13EVEQkg9d5EQS1iuYEKthiFpoJ67iEgIKbmLiISQhmWk+nS2o0jGUc9dRCSE1HOXlEl4IYnaDUNEUHKXFNJFmEUyh4ZlRERCSMldRCSENCwjydOsGJGsoZ67iEgIqeculVfqupvFRanWpCEUqZ7SBcWK6eB49lNyF6nD1uQMjb9gQoINdEHtrKFhGRGREFLPXaQuStADTzhMk6iHLxlLPXcRkRBSz11EolT/PTyU3KWsCuazJ/rqLiKZQ8ldRJJW3ge7pk9mFiV3SSzRfHb9E4tkPCV3EUlavA92DdNlJs2WEREJISV3EZEQ0rCMJKSv2yLZSz13EZEQUs+9jip3SltO8FOzYkSylpJ7HaVaISLhpuQedrp6kkidpORe16k+t0goKbnXFbp6kkidotkyIiIhpJ57HaE56yJ1i5J7SCS+gk4tByLhFucAffQ9NiHRNjqukw5K7nWE5qyL1C1K7lmmouGVMkl8Qs3FInVIOb3vhKWgNQ03rSpM7mZ2GDADOARwYLq7P2hmzYFZQC6RSRfnu/t/zMyAB4GzgB+Bi939nZoJX4pFT0qakNYwpA4r3fHQkGB6JdNz3w1c5+7vmFljYJmZvQJcDPzD3Seb2XhgPHAj0Ac4IridCDwS/JTKSNDr2Te+WaonNaFGoxGRLFNhcnf3dcC64P5WM1sJHAr0A04OVnsCWEQkufcDZri7A2+aWVMzax3sR2qaDl5JLdNFtTNTpcbczSwXOBZYChwSk7C/ITJsA5HE/1XMZkVBW4nkbmYjgZEAbdu2rWzcdUeZHrrGMSXLJHjP5m5/Km67Dv6nRtInMZlZI2AO8Ft3/z52WdBL98o8sbtPd/d8d89v1apVZTYVEZEKJNVzN7P6RBL7THd/Lmj+tni4xcxaA+uD9rXAYTGbtwnaRKQuSTREGPTkS/fQdaJdalXYcw9mvzwKrHT3+2IWPQ9cFNy/CJgX0z7CIroDWzTeLiJSu5LpufcALgRWmNnyoO1mYDIw28wuA74Azg+WvUhkGuQqIlMhL0llwCIiUrFkZsv8E7AEi0+Ls74DY6oZl1REB1ZFpBw6Q1VE0qNUB6X4HI7c8ZpFkwpK7ulWQQ+87EGmyBtfb3QJq8SXgNQ5HJWh5F5LVLVRJFDBLBpJDSX3TJHoSknqoUtdUUHST9hB0v9IXErutUxVG0VSS0k/PiX3VKuw4Ff8zXQCh0j5dNJT5Si5V5XGB0XSKnHBsuB/c0KCDetIcb3sTu4VJdg0/hErWxRpTQ3GIhIKif7f60iyrqzsTu6ZQAdCRTJS6Q5W4imW4RSK5J7oj1iZAy2VvnydiNSOiqZOJjrOVd3JC1Udes2QbxKhSO41qaLL1+mgjohUJB2dx1Ak90Sf0FU5001TFUWyRBV7yGWv9VrBcE2yQ68ZNskiFMm90uL8EfadKZroK6DG1kXCIJ1j77U5nTOcyb06pzdn2KeviNSSSn4TKPsNIJXBVF84k3sCiaYnQsWf5hpbF8lytXWgsyojAzWgTiX38hQnfp0FJyLlSXzyVK2GUaE6ldyrMj6uMXURSUZSIwMJatjXRI++TiV3EZGaUm5HcEKthRGl5C4iUtPSUMN+vxrbs4iIpI2Su4hICCm5i4iEkJK7iEgIKbmLiISQkruISAgpuYuIhJCSu4hICCm5i4iEkJK7iEgIKbmLiISQkruISAgpuYuIhJCSu4hICCm5i4iEkJK7iEgIKbmLiISQkruISAgpuYuIhFCNJHcz621mH5vZKjMbXxPPISIiiaU8uZtZPWAq0AfoBAwxs06pfh4REUmsJnruJwCr3H21u+8ECoF+NfA8IiKSwP41sM9Dga9iHhcBJ5ZeycxGAiODh9vM7OMqP+OdVuVNK6ElsLE2nqiaFGdqZUuckD2xKs7Sqp7D2iVaUBPJPSnuPh2Ynq7nrywze9vd89MdR0UUZ2plS5yQPbEqztpRE8Mya4HDYh63CdpERKSW1ERy/xdwhJm1N7OfAIOB52vgeUREJIGUD8u4+24zuwp4GagHPObuH6T6edIgW4aQFGdqZUuckD2xKs5aYO6e7hhERCTFdIaqiEgIKbmLiISQknspZjbIzD4ws71mlh/Tnmtm/zWz5cFtWsyy48xsRVBuYYqZ1fjE+0RxBstuCmL52MzOjGlPe1kIM5tgZmtjXsezKoo7XTLh9UrEzNYE77nlZvZ20NbczF4xs0+Dn83SFNtjZrbezN6PaYsbm0VMCV7j98ysW5rjzJr3Z4XcXbeYG3AU0BFYBOTHtOcC7yfY5i2gO2DA34A+aYyzE/Au0ABoD3xG5MB2veB+B+AnwTqd0vD6TgCuj9MeN+40vg8y4vUqJ741QMtSbfcA44P744G70xRbAdAt9v8lUWzAWcH/jAX/Q0vTHGdWvD+TuannXoq7r3T3pM+WNbPWQBN3f9Mj74IZQP+aiq9YOXH2AwrdfYe7fw6sIlISItPLQiSKO10y/fWKpx/wRHD/CWrhfRiPuy8GvivVnCi2fsAMj3gTaBr8T6UrzkQy7f1ZISX3ymlvZv82s/9nZr2CtkOJlFgoVhS0pUu88g+HltOeDlcFX8Efixk6yKT4IPPiKc2Bv5vZsqCUB8Ah7r4uuP8NcEh6QosrUWyZ+Dpnw/uzQmkrP5BOZvYq8NM4i25x93kJNlsHtHX3TWZ2HPAXMzu6xoKkynGmXXlxA48AdxFJTncBvwMurb3oQqOnu681s4OBV8zso9iF7u5mlpHznDM5NkL0/qyTyd3dT6/CNjuAHcH9ZWb2GfALIqUV2sSsmrJyC1WJk/LLP9RKWYhk4zazPwIvBA8zrWxFpsVTgruvDX6uN7O5RIYIvjWz1u6+LhjaWJ/WIEtKFFtGvc7u/m3x/Qx/f1ZIwzJJMrNWQa16zKwDcASwOviq+b2ZdQ9myYwA0tmrfh4YbGYNzKx9EOdbZEhZiFLjqQOA4pkKieJOl4x4veIxswPNrHHxfeAMIq/j88BFwWoXkd73YWmJYnseGBHMmukObIkZvql1WfT+rFi6j+hm2o3IH7SISC/9W+DloP084ANgOfAOcE7MNvlE3gSfAQ8TnPmbjjiDZbcEsXxMzMwdIjMTPgmW3ZKm1/dJYAXwHpF/mNYVxZ3G90LaX68EcXUgMnPj3eA9eUvQ3gL4B/Ap8CrQPE3xPU1kGHNX8B69LFFsRGbJTA1e4xXEzPxKU5xZ8/6s6KbyAyIiIaRhGRGREFJyFxEJISV3EZEQUnIXEQkhJXcRkRBScpdKMbM9QbW8983sr2bWtAr7yDezKQmWrTGzllWMbYKZXV+VbRPs72dm9myK9pVXqsJgUrHGvN4/i7PsYjN7OEXxzTSz78xsYCr2J+mn5C6V9V93z3P3Y4gUXRpT2R24+9vufk3qQ0std//a3VOV7PKIzJuvrOLX++sUxRGXuw8jQ07SktRQcpfqeIOgeJKZHW5mLwWFrF4zsyOD9kFBL/9dM1sctJ1sZi8E91uY2d8tUpv+T0ROaimunx9bZ/t6M5sQ3L/CzP4V7HOOmR2QbMBmdoKZvREUgHvdzDoG7X+KqeG9wczuiI0h6CX/xSK1yNeY2VVmNi7Yz5tm1jxYb5EF9fXNrGWw7k+A/wVcEOz/giCcTsH6q80sqQ87M7vEzD4xs7eAHjHtrYLX4l/BrUdM+yvFr6+ZfVHVb0aSXZTcpUqCUgynsa+3Nx242t2PA64Hfh+03w6c6e5dgb5xdnUH8E93PxqYC7RN4umfc/fjg32uJHJmYbI+Anq5+7FBbP8bwN0vd/c8IqVdNwKPx9n2GOBc4HhgEvBjsJ83iJSdiMsjJYNvB2YFvfBZwaIjgTOJ1IW5w8zqlxd4cGr8nUSSek8iNcaLPQjc7+7HEzmb+k9B+x3AguD1fZbkXl8JgTpZOEyqpaGZLSfSY19JpCJhI+CXwDO27yJUDYKfS4DHzWw28Fyc/RUQSZi4+3wz+08SMRxjZhOBpkAj4OVKxH8Q8ISZHUGk8l80oZpZDvAMkQ+pL8wst9S2C919K7DVzLYAfw3aVwBdKhFDsfkeFKQzs/VEyuAWlbP+icAid98QxDuLSPE6gNOJfBMoXrdJ8HfpSaRUBe7+UpKvr4SAkrtU1n/dPS8YCnmZyJj748DmoOdbgruPMrMTgd8AyyxSLjkZuyn5zTIn5v7jQH93f9fMLgZOrkT8dxFJ0gOC5L0oZtk0It8KXk2w7Y6Y+3tjHu9l3/9SbNyxMVe0vz1U7/9xP6C7u2+PbbSav+KjZCgNy0iVuPuPwDXAdcCPwOdmNgii18XsGtw/3N2XuvvtwAZKlk0FWAwMDdbtAxRfHOFb4OBgTL4BcHbMNo2BdcEwxrB48QVj4lfFWXQQ+0q1Xhyz/higsbtPTub3L8caoPgDLPZg7FYicVfHUuBXwWtSHxgUs+zvwNXFD8wsL7i7BDg/aDuDfa+vhJySu1SZu/+bSPW8IUSS7GVmVlypsPiSdP/XIhdyfh94nUglw1h3AgVm9gGR4Zkvg33vInIQ8i3gFSJj5cVuI5LolpRqj3UksClO+z3A/zGzf1Oyp3w90DnmoOqoin7/BO4FRgf7jz1wuZDIsEnsAdVK8Ugp3AlExviXEBkWK3YNkG+RKwh9CBTHfydwRvD6DyJyFaStAGb2osWZYinhoKqQEkrBbJxzg4OZWcvMtrl7o2ps3wDY4+67zewk4JF4w2fBuo8DL7h7Sub2S3qp5y6h5O5nZ3tiD3xvCU5iSlJb4F/BN6opwBXxVjKzmcCvgO3xlkv2Uc9dRCSE1HMXEQkhJXcRkRBSchcRCSEldxGREFJyFxEJof8PupVNwv8V54sAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Residual plot\n",
+    "xmin, xmax = -180, 180\n",
+    "bins = np.linspace(xmin, xmax, nb_bins + 1)\n",
+    "plt.hist(np.clip(df_leg.residual, xmin, xmax), bins=bins, histtype='step', lw=2, label=f'Legacy (std. = {df_leg.residual.std():.1f})')\n",
+    "plt.hist(np.clip(df_new.residual, xmin, xmax), bins=bins, histtype='step', lw=2, label=f'New (std. = {df_new.residual.std():.1f})')\n",
+    "plt.xlabel(f\"Residual, {var} [deg.]\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7eff47036af0>"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAEGCAYAAACJnEVTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAmEElEQVR4nO3deZhU1Z3/8fdXVhWQTQ0K2hDRiGxKKxiWqBgFoixONOACikpciKhxFDWTMCq/hziK0XEhOJCID4oLEhnFGAwwKK4Ng8ri0ghokw6bssWAgt/fH/d2T9FUdVfX1l19P6/nqaerzj333lO3qr916pxT55i7IyIi0XBQTRdARERyR0FfRCRCFPRFRCJEQV9EJEIU9EVEIqR+TRegKq1bt/aCgoKaLoaISN5YunTpFnc/PN62Wh/0CwoKKCoqquliiIjkDTNbn2ibmndERCJEQV9EJEIU9EVEIqTWt+mLyIG+/fZbSkpK2L17d00XRWpQ48aNadu2LQ0aNEh6HwV9kTxUUlJC06ZNKSgowMxqujhSA9ydrVu3UlJSQvv27ZPeT807Inlo9+7dtGrVSgE/wsyMVq1aVfvbnoK+SJ5SwJdU3gNq3hHJcwXjX87KcddN+klWjis1S0FfpDITDqti+/bclKMWatKkCbt27arpYsT1u9/9jpYtWzJy5Mi42xctWkTDhg354Q9/GHd7pp/bu+++y5gxY4CgLX7ChAkMGzbsgHxr165l+PDhbN26lR49evDkk0/SsGFDHn74YQ455BBGjx6ddlkU9EXqiEzVzLP1zSFX9u7dy/Tp01m2bFnCPIsWLaJJkyYJg36mde7cmaKiIurXr09paSndunXj/PPPp379/UPwbbfdxk033cTw4cO55pprmDZtGtdeey2jR4+md+/eGQn6atMXScaE7fvfJK41a9YwYMAAevToQd++ffnoo4/K03v16kWXLl341a9+RZMmTQDYtWsX/fv355RTTqFLly68+OKL5ceaMWMGXbt2pVu3blx22WXs3LmT9u3b8+233wKwY8eO/R6XWbBgAaecckp5QH3ooYfo1KkTXbt2Zfjw4axbt44pU6bwwAMP0L17d15//XXWrl3L6aefXl6+TDvkkEPKy7N79+64bfHuzoIFC/jpT38KwKhRo/jTn/5Uvn9BQQHvvvtu2mVRTV9EMmbMmDFMmTKFjh078s4773DdddexYMECxo0bx7hx4xgxYgRTpkwpz9+4cWPmzJlDs2bN2LJlC7169WLw4MGsWrWKe+65hzfffJPWrVvz5Zdf0rRpU8444wxefvllhg4dyqxZs7jgggsOGKO+ZMkSevToUf540qRJrF27lkaNGrFt2zaaN2/ONddcQ5MmTbjlllsAGDx4MNdeey0jR47kkUceSeq53nTTTSxcuPCA9OHDhzN+/PgD0t955x1Gjx7N+vXrefLJJw+o5W/dupXmzZuXp7dt25YNGzaUby8sLOT111/ntNNOS6p8iSjoi0hG7Nq1izfffJMLL7ywPG3Pnj0AvPXWW+W11osvvrg82Lo7d9xxB4sXL+aggw5iw4YNbNy4kQULFnDhhRfSunVrAFq2bAnAVVddxb333svQoUP5wx/+wOOPP35AOUpLSznxxBPLH3ft2pVLLrmEoUOHMnTo0LhlX7JkCbNnzwbgsssu47bbbqvy+T7wwANV5onVs2dPVq5cyerVqxk1ahQDBw6kcePGSe9/xBFHlH9zSoeCvkg6EnX0RrAJ6LvvvqN58+YsX7486X1mzpzJ5s2bWbp0KQ0aNKCgoKDScee9e/dm3bp1LFq0iH379tG5c+cD8hx88MH7HePll19m8eLF/Pd//zcTJ07kww8/jHvs6g5/rG5Nv8yJJ55IkyZNWLFiBYWFheXprVq1Ytu2bezdu5f69etTUlLC0UcfXb599+7dHHzwwdUqYzwK+iJ1RE13wDZr1oz27dvz3HPPceGFF+LufPDBB3Tr1o1evXoxe/ZsfvaznzFr1qzyfbZv384RRxxBgwYNWLhwIevXBzMCn3XWWQwbNoybb76ZVq1a8eWXX5bX9keOHMnFF1/Mv/3bv8Utx4knnkhxcTEQfBB98cUXnHnmmfTp04dZs2axa9cumjZtyo4dO8r36d27N7NmzeLSSy9l5syZST3f6tT0165dS7t27ahfvz7r16/no48+ouI6IWbGmWeeyfPPP8/w4cN54oknGDJkSPn2Tz75hN69eyd9zkTUkSuSiooduxHs4P36669p27Zt+W3y5MnMnDmTadOm0a1bN0466aTyjtnf/e53TJ48ma5du1JcXMxhhwXfkC655BKKioro0qULM2bM4Ac/+AEAJ510EnfeeSc/+tGP6NatGzfffHP5eS+55BK++uorRowYEbdcAwcOZPHixQDs27ePSy+9lC5dunDyySdzww030Lx5c84//3zmzJlT3pH74IMP8sgjj9ClS5f92tEBunfvnva1euONN+jWrRvdu3dn2LBhPProo+VNV4MGDeJvf/sbAL/97W+ZPHkyxx13HFu3buXKK68sP8aSJUv48Y9/nHZZcPdafevRo4eL1JjfNAtu2cqfolWrVmX9HJn0j3/8w7/77jt3d3/66ad98ODBKR/rueee80svvbTSPEOHDvVPPvkk5XPUNsuWLUv4nOO9F4AiTxBTq2zeMbN2wAzgSMCBqe7+oJm1BJ4BCoB1wEXu/pUFDWMPAoOAr4HL3X1ZeKxRQNl4qHvc/Yn0P7ZEpLZbunQpY8eOxd1p3rw506dPT+k4v/jFL3jllVeYN29epfkmTZpEaWkpHTt2TOk8tc2WLVu4++67M3KsZNr09wK/dPdlZtYUWGpm84HLgb+6+yQzGw+MB24DBgIdw1tP4DGgZ/gh8RugkODDY6mZzXX3rzLyTESk1urbty/vv/9+2sf5z//8z6TynXDCCZxwwglpn6+2yEizTqjKNn13Ly2rqbv7TmA1cDQwBCirqT8BDA3vDwFmhN8y3gaam1kb4Fxgvrt/GQb6+cCAjD0TERGpUrU6cs2sADgZeAc40t1Lw01/J2j+geAD4YuY3UrCtETp8c4zxsyKzKxo8+bN1SmiiIhUIumgb2ZNgNnAje6+I3Zb2HHgmSqUu09190J3Lzz88MMzdVgRkchLapy+mTUgCPgz3f2FMHmjmbVx99Kw+WZTmL4BaBeze9swbQNwRoX0RakXXUSAqmcCTfm40RqCGhVV1vTD0TjTgNXuPjlm01xgVHh/FPBiTPpIC/QCtofNQK8C55hZCzNrAZwTpomISI4kU9PvDVwGfGhmy8O0O4BJwLNmdiWwHrgo3DaPYLhmMcGQzSsA3P1LM7sbeC/Md5e7f5mJJyEiZK5mnuQ3BzPj5ptv5v777wfgvvvuY9euXUyYMCEz5SCYR+fqq6/mpZdeirt927ZtPPXUU1x33XVxt19++eWcd9555TNXZsKdd97JjBkz+OqrrxLOuZ9o/vxvvvmGs88+mwULFhww4VquJDN65w13N3fv6u7dw9s8d9/q7v3dvaO7n10WwMNRO9e7+/fdvYu7F8Uca7q7Hxfe/pDNJyYi2dWoUSNeeOEFtmzZkrVzTJ48mauvvjrh9m3btvHoo49m7fzxnH/++VVOcVw2f/7y5cv585//zM9//nP27t1Lw4YN6d+/P88880yOSnsgTcMgIimpX78+Y8aMiTsHzebNm/mXf/kXTj31VE499VSWLFkCQJcuXdi2bRvuTqtWrZgxYwYQzKczf/78A44ze/ZsBgwIRnavXLmS0047je7du9O1a1c+/fRTxo8fz5o1a+jevTv/+q//irszduxYTjjhBM4++2w2bdp0wDHT1atXL9q0aVNpnsrmzx86dGjS8/tkgyZcE5GUXX/99XTt2pVbb711v/Rx48Zx00030adPHz7//HPOPfdcVq9eTe/evVmyZAnHHnssHTp04PXXX2fkyJG89dZbPPbYY/sdY+3atbRo0YJGjRoBMGXKFMaNG8cll1zCN998w759+5g0aRIrVqwon9nzhRde4OOPP2bVqlVs3LiRTp06Vbna1MKFC7npppsOSD/kkEN48803U742iebP79y5M++9914Ve2ePgr6IpKxZs2aMHDmShx56aL9pf1977TVWrVpV/njHjh3s2rWLvn37snjxYo499liuvfZapk6dyoYNG2jRogWHHnrofscuLS0ldsj26aefzsSJEykpKeGCCy6IO8XC4sWLGTFiBPXq1eOoo47irLPOqvI5nHnmmdWaDjpZiebPr1evHg0bNmTnzp00bdo04+etioK+SF2RraGbVbjxxhs55ZRTuOKKK8rTvvvuO95+++0DFgnp168fjzzyCJ9//jkTJ05kzpw5PP/88/Tt2/eA41acF//iiy+mZ8+evPzyywwaNIjf//73dOjQIe3yZ6umXybe/Pl79uyp1gIqmaQ2fRFJS8uWLbnooouYNm1aedo555yz3zw5ZTXpdu3asWXLFj799FM6dOhAnz59uO++++jXr98Bxz3++ONZt25d+ePPPvuMDh06cMMNNzBkyBA++OADmjZtys6dO8vz9OvXj2eeeYZ9+/ZRWload5GTispq+hVv6QT8tWvXsnfvXoAD5s/funUrrVu3PmCZx1xRTV8EaqyWnBG14EdUv/zlL3n44YfLHz/00EPl7f179+6lX79+5Wvj9uzZk3379gHBRGy33347ffr0OeCYhx56KN///vcpLi7muOOO49lnn+XJJ5+kQYMGfO973+OOO+6gZcuW9O7dm86dOzNw4EDuvfdeFixYQKdOnTjmmGM4/fTTy4/361//msLCQgYPHpzWc7311lt56qmnytcTuOqqq5gwYQJz586lqKiIu+66izfeeINJkybRoEEDDjrooP3mz1+4cCE/+clP0ipDOiyYQaH2Kiws9KKioqoziqSjqqCfbGAtO06WA/Hq1av3Wwe2rpozZw5Lly7lnnvuqemiZMwFF1zApEmTOP744zNyvHjvBTNb6u6F8fKrpi8SqxbUmuX/DBs2jK1bt9Z0MTLmm2++YejQoRkL+KlQm75Inqrt39Iz5aqrrqrpImRMw4YNGTlyZMaOl8p7QEFfJA81btyYrVu3Ribwy4Hcna1bt1Z7FJCad0TyUNu2bSkpKUHrTURb48aNadu2bbX2UdAXyYZEHcMZ6jNo0KAB7du3z8ixJFrUvCMiEiGq6YtkUqKafD7/DkDqFNX0RUQiJJmVs6ab2SYzWxGT9oyZLQ9v68oWVzGzAjP7Z8y2KTH79DCzD82s2Mwesti5RkVEJCeSad75I/AwMKMswd1/VnbfzO4HYr/TrnH37nGO8xhwNfAOwepaA4BXql1iERFJWTIrZy0G4i5rGNbWLwKeruwY4cLpzdz9bQ8GFs8Ahla7tCIikpZ02/T7Ahvd/dOYtPZm9r9m9j9mVjZf6tFASUyekjAtLjMbY2ZFZlakccgiIpmTbtAfwf61/FLgGHc/GbgZeMrMmlX3oO4+1d0L3b0wdhEFERFJT8pDNs2sPnAB0KMszd33AHvC+0vNbA1wPLABiP3ZWNswTUREciidmv7ZwEfuXt5sY2aHm1m98H4HoCPwmbuXAjvMrFfYDzASeDGNc4uISAqSGbL5NPAWcIKZlZjZleGm4RzYgdsP+CAcwvk8cI27l3UCXwf8F1AMrEEjd0REcq7K5h13H5Eg/fI4abOB2QnyFwGdq1k+ERHJIP0iV0QkQhT0RUQiREFfRCRCFPRFRCJEQV9EJEIU9EVEIkRBX0QkQhT0RUQiREFfRCRCFPRFRCJEQV9EJEIU9EVEIkRBX0QkQhT0RUQiREFfRCRCFPRFRCKkykVUzGw6cB6wyd07h2kTgKuBzWG2O9x9XrjtduBKYB9wg7u/GqYPAB4E6gH/5e6TMvtURJIw4bCaLoFIjUqmpv9HYECc9AfcvXt4Kwv4nQiWUTwp3OdRM6sXrpv7CDAQ6ASMCPOKiEgOJbNc4mIzK0jyeEOAWe6+B1hrZsXAaeG2Ynf/DMDMZoV5V1W/yCIZMGF7TZdApEak06Y/1sw+MLPpZtYiTDsa+CImT0mYlig9LjMbY2ZFZla0efPmRNlERKSaUg36jwHfB7oDpcD9mSoQgLtPdfdCdy88/PDDM3loEZFIq7J5Jx5331h238weB14KH24A2sVkbRumUUm6iIjkSEo1fTNrE/NwGLAivD8XGG5mjcysPdAReBd4D+hoZu3NrCFBZ+/c1IstIiKpSGbI5tPAGUBrMysBfgOcYWbdAQfWAT8HcPeVZvYsQQftXuB6d98XHmcs8CrBkM3p7r4y009GREQql8zonRFxkqdVkn8iMDFO+jxgXrVKJ1LXJPqdgEYTSY7oF7kiIhGSUkeuiFRTopq8fiEsOaaavohIhCjoi4hEiIK+iEiEKOiLiESIgr6ISIQo6IuIRIiCvohIhCjoi4hEiIK+iEiEKOiLiESIgr6ISIQo6IuIRIiCvohIhFQZ9MOFzzeZ2YqYtP8ws4/ChdHnmFnzML3AzP5pZsvD25SYfXqY2YdmVmxmD5mZZeUZiYhIQsnU9P8IDKiQNh/o7O5dgU+A22O2rXH37uHtmpj0x4CrCZZQ7BjnmCIikmVVBn13Xwx8WSHtL+6+N3z4NsFC5wmFa+o2c/e33d2BGcDQlEosIiIpy0Sb/mjglZjH7c3sf83sf8ysb5h2NFASk6ckTIvLzMaYWZGZFW3evDkDRRQREUgz6JvZnQQLoM8Mk0qBY9z9ZOBm4Ckza1bd47r7VHcvdPfCww8/PJ0iiohIjJSXSzSzy4HzgP5hkw3uvgfYE95famZrgOOBDezfBNQ2TBMRkRxKqaZvZgOAW4HB7v51TPrhZlYvvN+BoMP2M3cvBXaYWa9w1M5I4MW0Sy8iItVSZU3fzJ4GzgBam1kJ8BuC0TqNgPnhyMu3w5E6/YC7zOxb4DvgGncv6wS+jmAk0MEEfQCx/QAiIpIDVQZ9dx8RJ3lagryzgdkJthUBnatVOhERySj9IldEJEIU9EVEIkRBX0QkQhT0RUQiREFfRCRCFPRFRCJEQV9EJEIU9EVEIkRBX0QkQhT0RUQiREFfRCRCUp5aWaRWm3BYTZdApFZSTV9EJEJU05e6bcL2mi6BSK2imr6ISIQo6IuIREhSzTtmNp1gPdxN7t45TGsJPAMUAOuAi9z9q3A5xAeBQcDXwOXuvizcZxTwq/Cw97j7E5l7KiJ5LFHHs5qnJMOSren/ERhQIW088Fd37wj8NXwMMJBgbdyOwBjgMSj/kPgN0BM4DfiNmbVIp/AiIlI9SdX03X2xmRVUSB5CsHYuwBPAIuC2MH2Guzvwtpk1N7M2Yd75ZWvmmtl8gg+Sp9N7CiJ5LFFNXkNOJUvSadM/0t1Lw/t/B44M7x8NfBGTryRMS5R+ADMbY2ZFZla0efPmNIooIiKxMjJk093dzDwTxwqPNxWYClBYWJix44pUV8H4lyvdvm7ST3JUEpHMSKemvzFstiH8uylM3wC0i8nXNkxLlC4iIjmSTk1/LjAKmBT+fTEmfayZzSLotN3u7qVm9irw/2I6b88Bbk/j/CI5U7FGX9U3AJHaKtkhm08TdMS2NrMSglE4k4BnzexKYD1wUZh9HsFwzWKCIZtXALj7l2Z2N/BemO+usk5dERHJjWRH74xIsKl/nLwOXJ/gONOB6UmXTqSWS1TjV1u/1Faae0ckC/RhILWVgr5IChIFb7X1S22noC9C5oK1PgykttOEayIiEaKavkgMtblLXaegL5JD6uCVmqbmHRGRCFFNXyQH1MErtYVq+iIiEaKgLyISIQr6IiIRoqAvIhIh6siVOi1fOkorlnNd4xoqiNR5qumLiESIavqS36pYQLy2/+gpYfkm5LQYEiEp1/TN7AQzWx5z22FmN5rZBDPbEJM+KGaf282s2Mw+NrNzM/MUREQkWSnX9N39Y6A7gJnVI1jvdg7BSlkPuPt9sfnNrBMwHDgJOAp4zcyOd/d9qZZBpNyE7fs9LGsjX1cDRRGpzTLVvNMfWOPu680sUZ4hwCx33wOsNbNi4DTgrQyVQaTuSdR8VeFDTiRZmerIHQ48HfN4rJl9YGbTYxZCPxr4IiZPSZh2ADMbY2ZFZla0efPmDBVRRETSrumbWUNgMHB7mPQYcDfg4d/7gdHVOaa7TwWmAhQWFnq6ZZS6L1+GZiarYPdTQJyO3io6rkWqkoma/kBgmbtvBHD3je6+z92/Ax4naMKBoM2/Xcx+bcM0ERHJkUy06Y8gpmnHzNq4e2n4cBiwIrw/F3jKzCYTdOR2BN7NwPlFav3QTJHaIq2gb2aHAj8Gfh6TfK+ZdSdo3llXts3dV5rZs8AqYC9wvUbuiIjkVlpB393/AbSqkHZZJfknAhPTOaeIiKROv8gVqcU0J49kmubeERGJENX0RWohzckj2aKgL5KHEv0uQaOYpCoK+lLrVfbDK7Vxi1SPgr5IHqpYo69rv0iW7FHQl7wRt+liQs6LIZLXNHpHRCRCFPRFRCJEQV9EJEIU9EVEIkRBX0QkQhT0RUQiREFfRCRCNE5fag39wCh9lf56WVM0CKrpi4hESiYWRl8H7AT2AXvdvdDMWgLPAAUEq2dd5O5fmZkBDwKDgK+By919WbplkLpFNdLqq+ya6RuUxMpU886Z7r4l5vF44K/uPsnMxoePbyNYRL1jeOsJPBb+FZEs08ycAtlr3hkCPBHefwIYGpM+wwNvA83NrE2WyiAiIhVkoqbvwF/MzIHfu/tU4Eh3Lw23/x04Mrx/NPBFzL4lYVppTBpmNgYYA3DMMcdkoIiS1yYcVtMlyGuJavJq9ommTAT9Pu6+wcyOAOab2UexG93dww+EpIUfHFMBCgsLq7WviIgklnbQd/cN4d9NZjYHOA3YaGZt3L00bL7ZFGbfALSL2b1tmCZStQnba7oEInkvrTZ9MzvUzJqW3QfOAVYAc4FRYbZRwIvh/bnASAv0ArbHNAOJiEiWpVvTPxKYE4zEpD7wlLv/2czeA541syuB9cBFYf55BMM1iwmGbF6R5vklD6ktWaTmpBX03f0zoFuc9K1A/zjpDlyfzjklfyi4i9Q+moZBaozGh4vknoK+ZJ2CexYkGsaaQme3frQVLZp7R0QkQlTTF8kniWryKfyATT/aiibV9EVEIkQ1fUmbaoYi+UNBX0TiUgdv3aSgLxmjYCBS+ynoi8h+1MFbt6kjV0QkQhT0RUQiREFfRCRC1KYvSVObroBG9eQ71fRFRCJENX2pNtXookmjeuqGlGv6ZtbOzBaa2SozW2lm48L0CWa2wcyWh7dBMfvcbmbFZvaxmZ2biScgIiLJS6emvxf4pbsvC5dMXGpm88NtD7j7fbGZzawTMBw4CTgKeM3Mjnf3fWmUQbKgxmpuKUwaJrWH2vrzQ8pBP1zbtjS8v9PMVgNHV7LLEGCWu+8B1ppZMcEi6m+lWgYRqf30YVC7ZKRN38wKgJOBd4DewFgzGwkUEXwb+IrgA+HtmN1KSPAhYWZjgDEAxxxzTCaKKCmosX/KFBYCkVBl35aydF3V1p9f0g76ZtYEmA3c6O47zOwx4G7Aw7/3A6Orc0x3nwpMBSgsLPR0yxh1+ueTmqAPg9opraBvZg0IAv5Md38BwN03xmx/HHgpfLgBaBeze9swTUTSVVktXn0lEiPloG9mBkwDVrv75Jj0NmF7P8AwYEV4fy7wlJlNJujI7Qi8m+r5pfrUhioi6dT0ewOXAR+a2fIw7Q5ghJl1J2jeWQf8HMDdV5rZs8AqgpE/12vkjkh0qYO3ZqQzeucNwOJsmlfJPhOBiameU0RE0qNf5NYh6iCTfKAO3pqloC8itYqafbJLQb8O0j+HxJVoFI9+FxEpCvqSexpCKHGo2Sc3FPRF6rpENXl9+EaSgr7UHDUriOScgn4e0tddEUmVgr6I5AWN6skMBf08pje7iFSXgr5kjzoKJQM0qiezFPRFoi7Px++r2ad6FPRrWCRqK3kSPESiQEFfJKryfPx+Vc0+lVWoovwtQEG/lojym1BqqTxv9pH4FPQlfXlSM5RoqKwCFYnm1Coo6OeI3mySN6pq9qkD3wCq+/9Yl76J5zzom9kA4EGgHvBf7j4p12XIhDodxFOtuefRP71IVJm75+5kZvWAT4AfAyXAe8AId1+VaJ/CwkIvKiqq9rmqCsoVP7lzFcRrVY0h080yCvrRVNX7KI/fFzVduUs1XpjZUncvjLct1zX904Bid/8MwMxmAUMI1s3NuHWNL068cULFvNkoQdXnrdXy+J9VapE87vPJWVyIo2D3U1k5bq6D/tHAFzGPS4CeFTOZ2RhgTPhwl5l9nMrJDFoDW1LZN8vyo1z/Hm8J5BqRH9er9lC5qqeWluu81vbblMt1bKINtbIj192nAlPTPY6ZFSX6ilOTVK7qUbmqR+WqnqiV66BMH7AKG4B2MY/bhmkiIpIDuQ767wEdzay9mTUEhgNzc1wGEZHIymnzjrvvNbOxwKsEQzanu/vKLJ4y7SaiLFG5qkflqh6Vq3oiVa6cDtkUEZGalevmHRERqUEK+iIiEZL3Qd/MLjSzlWb2nZkVVth2u5kVm9nHZnZugv3bm9k7Yb5nwg7mTJfxGTNbHt7WmdnyBPnWmdmHYb7q/wy5+uWaYGYbYso2KEG+AeE1LDaz8Tko13+Y2Udm9oGZzTGz5gny5eR6VfX8zaxR+BoXh++lgmyVJeac7cxsoZmtCt//4+LkOcPMtse8vr/OdrnC81b6uljgofB6fWBmp+SgTCfEXIflZrbDzG6skCcn18vMppvZJjNbEZPW0szmm9mn4d8WCfYdFeb51MxGpVQAd8/rG3AicAKwCCiMSe8EvA80AtoDa4B6cfZ/Fhge3p8CXJvl8t4P/DrBtnVA6xxeuwnALVXkqRdeuw5Aw/Cadspyuc4B6of3fwv8tqauVzLPH7gOmBLeHw48k4PXrg1wSni/KcH0JhXLdQbwUq7eT8m+LsAg4BXAgF7AOzkuXz3g78CxNXG9gH7AKcCKmLR7gfHh/fHx3vNAS+Cz8G+L8H6L6p4/72v67r7a3eP9YncIMMvd97j7WqCYYBqIcmZmwFnA82HSE8DQbJU1PN9FwNPZOkcWlE+d4e7fAGVTZ2SNu//F3feGD98m+D1HTUnm+Q8heO9A8F7qH77WWePupe6+LLy/E1hN8Iv3fDAEmOGBt4HmZtYmh+fvD6xx9/U5PGc5d18MfFkhOfY9lCgOnQvMd/cv3f0rYD4woLrnz/ugX4l4Uz5U/KdoBWyLCTDx8mRSX2Cju3+aYLsDfzGzpeFUFLkwNvyKPT3BV8pkrmM2jSaoFcaTi+uVzPMvzxO+l7YTvLdyImxOOhl4J87m083sfTN7xcxOylGRqnpdavo9NZzEFa+auF4AR7p7aXj/78CRcfJk5LrVymkYKjKz14Dvxdl0p7u/mOvyxJNkGUdQeS2/j7tvMLMjgPlm9lFYK8hKuYDHgLsJ/knvJmh6Gp3O+TJRrrLrZWZ3AnuBmQkOk/HrlW/MrAkwG7jR3XdU2LyMoAljV9hf8yegYw6KVWtfl7DPbjBwe5zNNXW99uPubmZZG0ufF0Hf3c9OYbdkpnzYSvDVsn5YQ0t5Woiqymhm9YELgB6VHGND+HeTmc0haFpI658l2WtnZo8DL8XZlJWpM5K4XpcD5wH9PWzQjHOMjF+vOJJ5/mV5SsLX+TCC91ZWmVkDgoA/091fqLg99kPA3eeZ2aNm1trdszq5WBKvS01OxzIQWObuGytuqKnrFdpoZm3cvTRs6toUJ88Ggn6HMm0J+jKrpS4378wFhocjK9oTfGK/G5shDCYLgZ+GSaOAbH1zOBv4yN1L4m00s0PNrGnZfYLOzBXx8mZKhXbUYQnOl/OpMyxYaOdWYLC7f50gT66uVzLPfy7BeweC99KCRB9UmRL2GUwDVrv75AR5vlfWt2BmpxH8v2f1wyjJ12UuMDIcxdML2B7TtJFtCb9t18T1ihH7HkoUh14FzjGzFmFT7DlhWvVku6c62zeCYFUC7AE2Aq/GbLuTYOTFx8DAmPR5wFHh/Q4EHwbFwHNAoyyV84/ANRXSjgLmxZTj/fC2kqCZI9vX7kngQ+CD8E3XpmK5wseDCEaHrMlRuYoJ2i6Xh7cpFcuVy+sV7/kDdxF8KAE0Dt87xeF7qUMOrlEfgma5D2Ku0yDgmrL3GTA2vDbvE3SI/zAH5Yr7ulQolwGPhNfzQ2JG3WW5bIcSBPHDYtJyfr0IPnRKgW/D2HUlQR/QX4FPgdeAlmHeQoIVBsv2HR2+z4qBK1I5v6ZhEBGJkLrcvCMiIhUo6IuIRIiCvohIhCjoi4hEiIK+iEiEKOhLXjOzfeGMiCvM7DkzO6SK/IssnI3VgtkgW2ewLNeY2cgMHetyMzsq5nFGyyrRpaAv+e6f7t7d3TsD3xCMu64R7j7F3Wdk6HCXE/wuQSSjFPSlLnkdOC6cF718Sgkzezic1qHazOzXZvZe+E1iavgr0qNs/7nZ95nZsRasT3BLuN8iM3vAzIrMbLWZnWpmL1gwD/o9YZ4C239O9VvCY/yU4Ec5M8PjHxxm+YWZLbNgrvofpHiNJOIU9KVOCOe8GUjwC89MetjdTw2/SRwMnOfufwu/XXQHHgdme/xper9x90KCdRpeBK4HOgOXm1nCWTjd/XmgCLgkPM8/w01b3P0UgonybsnUE5RoUdCXfHewBSuRFQGfE8xHk0lnWrAa1ocEay+UT7drZr2Bq0k8M2nZHD0fAis9mAN/D8HiF+0S7FOZsknVlgIFKewvkh+zbIpU4p9hjbucme1l/wpN41QObGaNgUcJ5ob5wswmlB0rnKxuGsH8O7sSHGJP+Pe7mPtlj+sTTBtdnXKWHWMf+t+VFKmmL3XReqBTOMNqc4KVkiplZn81s4oLUpQF4S3hvPU/DfM2IJhg7TZ3/ySNcm4EjjCzVmbWiGAq6TI7CZZBFMko1Rakzglr5c8STOm7FvjfyvKb2UHAcVRYws7dt4XrDKwgWM3ovXDTDwk6Wv/dzP49TIu7qHwV5fzWzO4imJlzA/BRzOY/AlPM7J/A6dU9tkgimmVTIs/MOgOj3f3mmi6LSLYp6IuIRIja9EVEIkRBX0QkQhT0RUQiREFfRCRCFPRFRCJEQV9EJEL+PyY0HqXX9OnkAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Pull plot\n",
+    "bins = np.linspace(-10, 10, 50 + 1)\n",
+    "plt.hist(df_leg.pull, bins=bins, histtype='step', lw=2, label=f'Legacy (std. = {df_leg.pull.std():.1f})')\n",
+    "plt.hist(df_new.pull, bins=bins, histtype='step', lw=2, label=f'New (std. = {df_new.pull.std():.1f})')\n",
+    "plt.xlabel(f\"Pull, {var}\")\n",
+    "plt.legend()"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "8fb322b307301711a693816effa672bbcb349d6cb1f5c0259c371a01fded53d2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.12 64-bit ('gnn_py38': conda)",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/gnn_reco/legacy/original.py
+++ b/src/gnn_reco/legacy/original.py
@@ -117,6 +117,8 @@ class Dynedge(torch.nn.Module):
                 pred = np.arctan2(x[:,0].cpu().numpy(),x[:,1].cpu().numpy()).reshape(-1,1)
                 if self.target == 'zenith':
                     pred = torch.tensor(self.scalers['truth'][self.target].inverse_transform(pred),dtype = torch.float32)
+                else:
+                    pred = torch.tensor(pred, dtype=torch.float32)
                 sigma = abs(1/x[:,2]).cpu()
                 return torch.cat((pred,sigma.reshape(-1,1)),dim = 1)
             else:

--- a/src/gnn_reco/models/detector/__init__.py
+++ b/src/gnn_reco/models/detector/__init__.py
@@ -1,1 +1,2 @@
 from .detector import Detector
+from .icecube import IceCube86, IceCubeDeepCore

--- a/src/gnn_reco/models/detector/icecube.py
+++ b/src/gnn_reco/models/detector/icecube.py
@@ -5,8 +5,7 @@ from gnn_reco.data.constants import FEATURES
 from gnn_reco.models.detector import Detector
 
 class IceCube86(Detector):
-    """`Detector` class for IceCube-86.
-    """
+    """`Detector` class for IceCube-86."""
 
     # Implementing abstract class attribute
     features = FEATURES.ICECUBE86
@@ -47,3 +46,7 @@ class IceCube86(Detector):
         data.x[:,6] /= 0.05  # pmt_area
 
         return data
+
+
+class IceCubeDeepCore(IceCube86):
+    """`Detector` class for IceCube-DeepCore."""

--- a/src/gnn_reco/models/task/reconstruction.py
+++ b/src/gnn_reco/models/task/reconstruction.py
@@ -1,36 +1,53 @@
+import numpy as np
 import torch
 
 from gnn_reco.components.loss_functions import LossFunction
 from gnn_reco.models.task import Task
 from gnn_reco.utils import eps_like
 
-class AngularReconstruction(Task):
+class AzimuthReconstruction(Task):
     # Requires two features: untransformed points in (x,y)-space.
     nb_inputs = 2
 
     def _forward(self, x):
         # Transform outputs to angle and prepare prediction
-        return torch.atan2(x[:,1], x[:,0]).unsqueeze(1)  # atan(y,x)
+        radius = torch.sqrt(x[:,0]**2 + x[:,1]**2)
+        beta = 0.01
+        kl_loss = torch.mean(radius**2 - torch.log(radius) - 1)
+        self._regularisation_loss += beta * kl_loss
+        return torch.atan2(x[:,1], x[:,0]).unsqueeze(1) + np.pi  # atan(y,x) -> [-pi, pi]
+        
+        #return torch.sigmoid(x[:,:1]) * 2 * np.pi
 
-class AngularReconstructionWithKappa(AngularReconstruction):
-    # Requires one feature in addition to `AngularReconstruction`: kappa (unceratinty; 1/variance).
+class ZenithReconstruction(Task):
+    # Requires two features: untransformed points in (x,y)-space.
+    nb_inputs = 1
+
+    def _forward(self, x):
+        # Transform outputs to angle and prepare prediction
+        return torch.sigmoid(x[:,:1]) * np.pi
+
+
+class AzimuthReconstructionWithKappa(AzimuthReconstruction):
+    # Requires one feature in addition to `AzimuthReconstruction`: kappa (unceratinty; 1/variance).
     nb_inputs = 3
 
     def _forward(self, x):
         # Transform outputs to angle and prepare prediction
         angle = super()._forward(x[:,:2]).squeeze(1)
-        kappa = torch.nn.functional.softplus(x[:,2]) + eps_like(x)
+        kappa = torch.abs(x[:,2]) + eps_like(x)
         return torch.stack((angle, kappa), dim=1)
 
-class AngularReconstructionWithUncertainty(AngularReconstruction):
-    # Requires one feature in addition to `AngularReconstruction`: log-variance (uncertainty).
-    nb_inputs = 3
+class ZenithReconstructionWithKappa(ZenithReconstruction):
+    # Requires one feature in addition to `ZenithReconstruction`: kappa (unceratinty; 1/variance).
+    nb_inputs = 2
 
     def _forward(self, x):
         # Transform outputs to angle and prepare prediction
-        angle = super()._forward(x[:,:2]).squeeze(1)
-        log_var = x[:,2]
-        return torch.stack((angle, log_var), dim=1)
+        angle = super()._forward(x[:,:1]).squeeze(1)
+        kappa = torch.abs(x[:,1]) + eps_like(x)
+        return torch.stack((angle, kappa), dim=1)
+        
 
 class EnergyReconstruction(Task):
     # Requires one feature: untransformed energy

--- a/src/gnn_reco/models/task/reconstruction.py
+++ b/src/gnn_reco/models/task/reconstruction.py
@@ -12,7 +12,7 @@ class AzimuthReconstruction(Task):
     def _forward(self, x):
         # Transform outputs to angle and prepare prediction
         radius = torch.sqrt(x[:,0]**2 + x[:,1]**2)
-        beta = 0.01
+        beta = 1e-4
         kl_loss = torch.mean(radius**2 - torch.log(radius) - 1)
         self._regularisation_loss += beta * kl_loss
         return torch.atan2(x[:,1], x[:,0]).unsqueeze(1) + np.pi  # atan(y,x) -> [-pi, pi]

--- a/src/gnn_reco/models/task/task.py
+++ b/src/gnn_reco/models/task/task.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
 from typing import Union
+
+import torch
 try:
     from typing import final
 except ImportError:  # Python version < 3.8
@@ -31,6 +33,7 @@ class Task(Module):
 
     @final
     def forward(self, x: Union[Tensor, Data]) -> Union[Tensor, Data]:
+        self._regularisation_loss = 0
         x = self._affine(x)
         return self._forward(x)
 
@@ -41,6 +44,5 @@ class Task(Module):
     @final
     def compute_loss(self, pred: Union[Tensor, Data], data: Data) -> Tensor:
         target = data[self._target_label]
-        loss = self._loss_function(pred, target)
+        loss = self._loss_function(pred, target) + self._regularisation_loss
         return loss
-    

--- a/studies/compare_new_vs_legacy_model_implementation.py
+++ b/studies/compare_new_vs_legacy_model_implementation.py
@@ -1,0 +1,151 @@
+import numpy as np
+from timer import timer
+import logging
+
+import torch
+
+from gnn_reco.components.loss_functions import  VonMisesFisher2DLoss
+from gnn_reco.components.utils import fit_scaler
+from gnn_reco.data.constants import FEATURES, TRUTH
+from gnn_reco.data.utils import get_equal_proportion_neutrino_indices
+from gnn_reco.models import Model
+from gnn_reco.models.detector import IceCubeDeepCore
+from gnn_reco.models.gnn import DynEdge, ConvNet
+from gnn_reco.models.graph_builders import KNNGraphBuilder
+from gnn_reco.models.task.reconstruction import AngularReconstructionWithKappa, AzimuthReconstructionWithKappa, ZenithReconstructionWithKappa
+from gnn_reco.models.training.callbacks import PiecewiseLinearScheduler
+from gnn_reco.models.training.trainers import Trainer, Predictor
+from gnn_reco.models.training.utils import make_train_validation_dataloader, save_results
+from gnn_reco.legacy.original import (
+    Dynedge as LegacyDynedge,  
+    vonmises_sinecosine_loss,
+    log_cosh,
+    Trainer as LegacyTrainer,
+    Predictor as LegacyPredictor,
+)
+from sklearn.preprocessing import RobustScaler
+
+# Configurations
+timer.set_level(logging.INFO)
+logging.basicConfig(level=logging.INFO)
+torch.multiprocessing.set_sharing_strategy('file_system')
+
+# Constants
+features = FEATURES.ICECUBE86
+truth = TRUTH.ICECUBE86
+
+
+def train_legacy_model(training_dataloader, validation_dataloader, target, n_epochs, patience, scalers, device, db, archive):
+    model = LegacyDynedge(k = 8, device = device, n_outputs= 3, scalers = scalers, target = target).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-5,eps = 1e-3)
+    scheduler = PiecewiseLinearScheduler(training_dataloader, start_lr = 1e-5, max_lr= 1e-3, end_lr = 1e-5, max_epochs= n_epochs)
+    loss_func = vonmises_sinecosine_loss
+
+    trainer = LegacyTrainer(training_dataloader = training_dataloader, validation_dataloader= validation_dataloader, 
+                    optimizer = optimizer, n_epochs = n_epochs, loss_func = loss_func, target = target, 
+                    device = device, scheduler = scheduler, patience= patience)
+
+    trained_model = trainer(model)
+
+    predictor = LegacyPredictor(dataloader = validation_dataloader, target = target, device = device, output_column_names= [target + '_pred', target + '_var'])
+    results = predictor(trained_model)
+    save_results(db, f'dynedge_{target}_legacy', results, archive, trained_model)
+
+
+def train_new_model(training_dataloader, validation_dataloader, target, n_epochs, patience, scalers, device, db, archive):
+    
+    # Building model
+    detector = IceCubeDeepCore(
+        graph_builder=KNNGraphBuilder(nb_nearest_neighbours=8),
+        scalers=scalers['input']['SRTTWOfflinePulsesDC'],
+    )
+    gnn = DynEdge(
+        nb_inputs=detector.nb_outputs,
+    )
+    task_ = {
+        'zenith': ZenithReconstructionWithKappa,
+        'azimuth': AzimuthReconstructionWithKappa,
+    }[target]
+    task = task_(
+        hidden_size=gnn.nb_outputs, 
+        target_label=target, 
+        loss_function=VonMisesFisher2DLoss(),
+    )
+    model = Model(
+        detector=detector,
+        gnn=gnn,
+        tasks=[task],
+        device=device,
+    )
+
+    # Training it
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-5, eps=1e-03)
+    scheduler = PiecewiseLinearScheduler(training_dataloader, start_lr=1e-5, max_lr=1e-3, end_lr=1e-5, max_epochs=n_epochs)
+
+    trainer = Trainer(
+        training_dataloader=training_dataloader,
+        validation_dataloader=validation_dataloader, 
+        optimizer=optimizer,
+        n_epochs=n_epochs, 
+        scheduler=scheduler,
+        patience=patience,
+    )
+
+    try:
+        trainer(model)
+    except KeyboardInterrupt:
+        print("[ctrl+c] Exiting gracefully.")
+        pass
+
+    # Running inference
+    predictor = Predictor(
+        dataloader=validation_dataloader, 
+        target=target, 
+        device=device, 
+        output_column_names=[target + '_pred', target + '_kappa'],
+    )
+    results = predictor(model)
+    save_results(db, f'dynedge_{target}', results,archive, model)
+
+
+# Main function definition
+def main(target):
+
+    print(f"features: {features}")
+    print(f"truth: {truth}")
+
+    # Configuraiton
+    db = '/groups/icecube/leonbozi/datafromrasmus/GNNReco/data/databases/dev_level7_noise_muon_nu_classification_pass2_fixedRetro_v3/data/dev_level7_noise_muon_nu_classification_pass2_fixedRetro_v3.db'
+    pulsemap = 'SRTTWOfflinePulsesDC'
+    batch_size = 1024
+    num_workers = 10
+    device = 'cuda'
+    n_epochs = 30
+    patience = 5
+    archive = '/groups/icecube/asogaard/gnn/results/von_mises-fisher_test'
+
+    # Scalers
+    scalers = fit_scaler(db, features, truth, pulsemap)
+
+    # Common variables
+    train_selection, _ = get_equal_proportion_neutrino_indices(db)
+    train_selection = train_selection[0:500000]
+    
+    training_dataloader, validation_dataloader = make_train_validation_dataloader(
+        db, 
+        train_selection, 
+        pulsemap, 
+        features, 
+        truth, 
+        batch_size=batch_size, 
+        num_workers=num_workers,
+    )
+    
+    train_legacy_model(training_dataloader, validation_dataloader, target, n_epochs, patience, scalers, device, db, archive)
+    train_new_model(training_dataloader, validation_dataloader, target, n_epochs, patience, scalers, device, db, archive)
+    
+    
+# Main function call
+if __name__ == "__main__":
+    main('azimuth')
+    main('zenith')

--- a/studies/compare_new_vs_legacy_model_implementation.py
+++ b/studies/compare_new_vs_legacy_model_implementation.py
@@ -140,8 +140,20 @@ def main(target):
         num_workers=num_workers,
     )
     
-    train_legacy_model(training_dataloader, validation_dataloader, target, n_epochs, patience, scalers, device, db, archive)
-    train_new_model(training_dataloader, validation_dataloader, target, n_epochs, patience, scalers, device, db, archive)
+    args = (
+        training_dataloader,
+        validation_dataloader,
+        target,
+        n_epochs,
+        patience,
+        scalers,
+        device,
+        db,
+        archive,
+    )
+
+    train_legacy_model(*args)
+    train_new_model(*args)
     
     
 # Main function call

--- a/studies/compare_new_vs_legacy_model_implementation.py
+++ b/studies/compare_new_vs_legacy_model_implementation.py
@@ -12,7 +12,7 @@ from gnn_reco.models import Model
 from gnn_reco.models.detector import IceCubeDeepCore
 from gnn_reco.models.gnn import DynEdge, ConvNet
 from gnn_reco.models.graph_builders import KNNGraphBuilder
-from gnn_reco.models.task.reconstruction import AngularReconstructionWithKappa, AzimuthReconstructionWithKappa, ZenithReconstructionWithKappa
+from gnn_reco.models.task.reconstruction import AzimuthReconstructionWithKappa, ZenithReconstructionWithKappa
 from gnn_reco.models.training.callbacks import PiecewiseLinearScheduler
 from gnn_reco.models.training.trainers import Trainer, Predictor
 from gnn_reco.models.training.utils import make_train_validation_dataloader, save_results
@@ -23,7 +23,6 @@ from gnn_reco.legacy.original import (
     Trainer as LegacyTrainer,
     Predictor as LegacyPredictor,
 )
-from sklearn.preprocessing import RobustScaler
 
 # Configurations
 timer.set_level(logging.INFO)
@@ -129,15 +128,15 @@ def main(target):
 
     # Common variables
     train_selection, _ = get_equal_proportion_neutrino_indices(db)
-    train_selection = train_selection[0:500000]
+    train_selection = train_selection[0:50000]
     
     training_dataloader, validation_dataloader = make_train_validation_dataloader(
         db, 
         train_selection, 
         pulsemap, 
+        batch_size,
         features, 
         truth, 
-        batch_size=batch_size, 
         num_workers=num_workers,
     )
     


### PR DESCRIPTION
Have added:
* separate zenith and azimuth reconstruction tasks  to better reflect their different natures,
* an example script for training new and legacy models; closes #55 
* an example notebook for  visualising a few results; closes #54, closes #44
The punchline, as far as I can tell, is the performance is about the same, but the exact von Mises-Fisher loss yields better (i.e. more-unit-variance-y) pulls and are easier to motivate in a paper. 

@RasmusOrsoe, let me know if you find similar results using your own plotting scripts.

